### PR TITLE
Move Disclaimer To MD Files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -101,3 +101,6 @@ If your contribution or PR is not formatted correctly, I'll let you know and giv
 - [Jonathan Yee](https://github.com/jonyeezs)
 - [Matt Ackard](https://github.com/mattackard)
 - [Adrienne Tacke](https://github.com/adriennetacke)
+
+
+**Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com) or any company offering swag. Hacktoberfest is a trademark of DigitialOcean, LLC.**

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ It's that time of year again! Time to get rewarded for contributing to the Open 
 
 This repo seeks to document all of the companies giving away swag for Hacktoberfest 2018 and how you can get your hands on some free gifts for your time and help.
 
+**Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com) or any company offering swag. Hacktoberfest is a trademark of DigitialOcean, LLC.**
+
 ## Quick Jump To
 
 - [A to Z Order of Companies](#a-to-z-order-of-companies)

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -30,9 +30,6 @@
         <a class="github-button" href="https://github.com/crweiner/hacktoberfest-swag-list/subscription" data-icon="octicon-eye" data-show-count="true" aria-label="Watch crweiner/hacktoberfest-swag-list on GitHub">Watch</a>
         <a class="github-button" href="https://github.com/crweiner/hacktoberfest-swag-list/fork" data-icon="octicon-repo-forked" data-show-count="true" aria-label="Fork crweiner/hacktoberfest-swag-list on GitHub">Fork</a>
         <a class="github-button" href="https://github.com/crweiner/hacktoberfest-swag-list" data-icon="octicon-star" data-show-count="true" aria-label="Star crweiner/hacktoberfest-swag-list on GitHub">Star</a>
-        <p><strong>
-          Disclaimer: This website is a fan and community made creation. It is not affiliated with <a href="https://hacktoberfest.digitalocean.com/">Hacktoberfest</a> or any company offering swag.
-          </strong></p>
         {% endif %}
 
         {% if site.github.is_user_page %}


### PR DESCRIPTION
Instead of writing the disclaimer into the HTML Minimal Jekyll template, this moves the disclaimer to the MD files themselves.

Attempt to Fix #33. Also see #34 for moving to the footer.