### PR TITLE
Update information about Les-Tilleuls.coop

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,6 +118,7 @@ If your contribution or PR is not formatted correctly, I'll let you know and giv
 - [Dean Mckenzie](https://github.com/tuxhedoh)
 - [Willy Nzesseu](https://github.com/WilChrist)
 - [Robin Collet](https://github.com/taminoful)
+- [Patrick Passarella](https://github.com/PatrickRNG)
 - [Oorjit Chowdhary](https://github.com/oorjitchowdhary)
 - [Caio Reis](https://github.com/caioreis123)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -120,6 +120,7 @@ If your contribution or PR is not formatted correctly, I'll let you know and giv
 - [Robin Collet](https://github.com/taminoful)
 - [Patrick Passarella](https://github.com/PatrickRNG)
 - [Oorjit Chowdhary](https://github.com/oorjitchowdhary)
+- [Jimmy Nguyen](https://github.com/Stukongeluk)
 - [Caio Reis](https://github.com/caioreis123)
 
 Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/) or any company offering swag.

--- a/README.md
+++ b/README.md
@@ -148,12 +148,14 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Not clarified by now.
 - **Notes**: PRs are reviewed each Thursday between 8AM - 8PM BST/GMT. See this announcement in their [GitHub Issue](https://github.com/salesagility/SuiteCRM/issues/7911) or [this blog post](https://suitecrm.com/community-diary-sept-2019-edition/).
 
+
 #### **Sense/Net**
 
-- **Swag**: The first 100 participants who makes a pull request to any of the repositories under the Sense/Net organization on GitHub between October 1 and October 31 will receive a sensenet #hacktoberfest limited edition T-shirt.
-- **Requirements**: Make at least one pull-request in one of the repositories under the Sense/Net organization. Note that contributions don’t have to come in the form of code. Improving documentation is also a great place to start.
-- **How to sign up**: Use the [form](https://www.sensenet.com/Hacktoberfest2019) on their website
-- **Notes**: See the blog post [here](https://community.sensenet.com/blog/2019/10/01/hacktoberfest-is-here) for further details
+- **Swag**: SenseNet Limited edition T-shirt (first 100 participants)
+- **Requirements**: The first 100 participants who make a pull request to any of the repositories under the [Sense/Net organization on GitHub](https://github.com/SenseNet/) between October 1 and October 31.
+- **How to sign up**: Sign up to the Hacktoberfest site and share your contact details via [this form](https://www.sensenet.com/Hacktoberfest2019)
+- **Notes**:  See their [blog post](https://community.sensenet.com/blog/2019/10/01/hacktoberfest-is-here). Note that contributions don’t have to come in the form of code. Improving documentation is also a great place to start.
+
 
 ### T
 
@@ -204,7 +206,6 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Make a PR on any of these: [The Hasura GraphQL Engine](https://github.com/hasura/graphql-engine) and/or [The GraphQL Tutorial Series](https://github.com/hasura/learn-graphql)
 - **Notes**: See the [blog post](https://blog.hasura.io/hasura-joins-hacktoberfest-2019/) for more information and keep updated at Hasura [twitter](https://twitter.com/hasurahq)
 
-
 #### **LBRY** (Sticker, LBRY t-shirt*, and more)
 
 - **Requirements**:
@@ -214,12 +215,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Notes**: See this announcement from [Jeremy Kauffman's blog post](https://lbry.com/news/hacktoberfest-2019) and read [how to contribute](https://lbry.tech/contribute)
 
 
-#### **Sense/Net**
+#### **Sense/Net** (Limited edition t-shirt)
 
-- **Swag**: The first 100 participants who makes a pull request to any of the repositories under the Sense/Net organization on GitHub between October 1 and October 31 will receive a sensenet #hacktoberfest limited edition T-shirt.
-- **Requirements**: Make at least one pull-request in one of the repositories under the Sense/Net organization. Note that contributions don’t have to come in the form of code. Improving documentation is also a great place to start.
-- **How to sign up**: Use the [form](https://www.sensenet.com/Hacktoberfest2019) on their website
-- **Notes**: See the blog post [here](https://community.sensenet.com/blog/2019/10/01/hacktoberfest-is-here) for further details
+- **Swag**: SenseNet Limited edition T-shirt (first 100 participants)
+- **Requirements**: The first 100 participants who make a pull request to any of the repositories under the [Sense/Net organization on GitHub](https://github.com/SenseNet/) between October 1 and October 31.
+- **How to sign up**: Sign up to the Hacktoberfest site and share your contact details via [this form](https://www.sensenet.com/Hacktoberfest2019)
+- **Notes**:  See their [blog post](https://community.sensenet.com/blog/2019/10/01/hacktoberfest-is-here). Note that contributions don’t have to come in the form of code. Improving documentation is also a great place to start.
+
 
 #### **Valor Software** (Pen and Sticker)
 

--- a/README.md
+++ b/README.md
@@ -148,6 +148,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Not clarified by now.
 - **Notes**: PRs are reviewed each Thursday between 8AM - 8PM BST/GMT. See this announcement in their [GitHub Issue](https://github.com/salesagility/SuiteCRM/issues/7911) or [this blog post](https://suitecrm.com/community-diary-sept-2019-edition/).
 
+#### **Sense/Net**
+
+- **Swag**: The first 100 participants who makes a pull request to any of the repositories under the Sense/Net organization on GitHub between October 1 and October 31 will receive a sensenet #hacktoberfest limited edition T-shirt.
+- **Requirements**: Make at least one pull-request in one of the repositories under the Sense/Net organization. Note that contributions don’t have to come in the form of code. Improving documentation is also a great place to start.
+- **How to sign up**: Use the [form](https://www.sensenet.com/Hacktoberfest2019) on their website
+- **Notes**: See the blog post [here](https://community.sensenet.com/blog/2019/10/01/hacktoberfest-is-here) for further details
+
 ### T
 
 #### **Twilio**
@@ -197,6 +204,7 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Make a PR on any of these: [The Hasura GraphQL Engine](https://github.com/hasura/graphql-engine) and/or [The GraphQL Tutorial Series](https://github.com/hasura/learn-graphql)
 - **Notes**: See the [blog post](https://blog.hasura.io/hasura-joins-hacktoberfest-2019/) for more information and keep updated at Hasura [twitter](https://twitter.com/hasurahq)
 
+
 #### **LBRY** (Sticker, LBRY t-shirt*, and more)
 
 - **Requirements**:
@@ -204,6 +212,14 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
   - Contributes anything of any substance* will receive a sticker, LBRY t-shirt, and more.
 - **How to sign up**: PR to LBRY repos.
 - **Notes**: See this announcement from [Jeremy Kauffman's blog post](https://lbry.com/news/hacktoberfest-2019) and read [how to contribute](https://lbry.tech/contribute)
+
+
+#### **Sense/Net**
+
+- **Swag**: The first 100 participants who makes a pull request to any of the repositories under the Sense/Net organization on GitHub between October 1 and October 31 will receive a sensenet #hacktoberfest limited edition T-shirt.
+- **Requirements**: Make at least one pull-request in one of the repositories under the Sense/Net organization. Note that contributions don’t have to come in the form of code. Improving documentation is also a great place to start.
+- **How to sign up**: Use the [form](https://www.sensenet.com/Hacktoberfest2019) on their website
+- **Notes**: See the blog post [here](https://community.sensenet.com/blog/2019/10/01/hacktoberfest-is-here) for further details
 
 #### **Valor Software** (Pen and Sticker)
 

--- a/README.md
+++ b/README.md
@@ -104,8 +104,8 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 
 - **Swag**: An API Platform surprise gift
 - **Requirements**: Create at least 3 PRs to [API Platform repositories](https://github.com/api-platform) during October.
-- **How to sign up**: Not clarified by now.
-- **Notes**: See this announcement from [Kévin Dunglas on his Blog](https://dunglas.fr/2019/09/api-platform-2-5-revamped-admin-new-api-testing-tool-next-js-and-quasar-app-generators-patch-and-json-schema-support-improved-openapi-and-graphql-support/).
+- **How to sign up**: Complete 3 PRs and [sign up here](https://cooptilleuls.typeform.com/to/CG0pLd).
+- **Notes**: See this announcement from [the companies website](https://les-tilleuls.coop/fr/blog/article/celebrate-hacktoberfest-with-api-platform).
 
 ### O
 
@@ -172,6 +172,15 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Requirements**: Get one pull request merged into any project on [twilio-labs](https://github.com/twilio-labs) to win a collection of stickers or contribute to two or more pull requests to earn a pair of Twilio socks.
 - **How to sign up**: Sign up to GitHub, Make pull requests as mentioned above, fill out this [form](https://docs.google.com/forms/d/e/1FAIpQLSc0MaHgfVhNkZdfv9R4Zcs8nfoQbcbJxRQaHmOctsVA80H1QA/viewform) before November 15th and wait for your special edition Hacktoberfest swag from Twilio.
 - **Notes**:  See this page for their [official announcement](https://www.twilio.com/blog/ahoy-hacktoberfest-2019).
+
+### S
+
+#### **SalesAgility**
+
+- **Swag**: SuiteCRM contributor mug
+- **Requirements**: Create at least 1 merged PR to [the SuiteCRM, SuiteDocs or SuitePortal repositories](https://github.com/api-platform) during October.
+- **How to sign up**: Not clarified by now.
+- **Notes**: PRs are reviewed each Thursday between 8AM - 8PM BST/GMT. See this announcement in their [GitHub Issue](https://github.com/salesagility/SuiteCRM/issues/7911) or [this blog post](https://suitecrm.com/community-diary-sept-2019-edition/).
 
 ### U
 
@@ -312,6 +321,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Share your contact details via [this form with the Uno Platform team](https://forms.office.com/Pages/ResponsePage.aspx?id=Ye9TbdG2UEGuC0O5DnXgzai0HkTgxONNjPmzuZ5zgdRUQzFJMVBPSU8xWDBUUlNOTExCWFUwQjNBNy4u).
 - **Notes**: See the [blog post](https://platform.uno/uno-is-joining-hacktoberfest-2019/) for more information.
 
+#### **SalesAgility**
+
+- **Swag**: SuiteCRM contributor mug
+- **Requirements**: Create at least 1 merged PR to [the SuiteCRM, SuiteDocs or SuitePortal repositories](https://github.com/api-platform) during October.
+- **How to sign up**: Not clarified by now.
+- **Notes**: PRs are reviewed each Thursday between 8AM - 8PM BST/GMT. See this announcement in their [GitHub Issue](https://github.com/salesagility/SuiteCRM/issues/7911) or [this blog post](https://suitecrm.com/community-diary-sept-2019-edition/).
+
 ### 2 or more PRs
 
 #### **CircleCI** (Limited-Edition T-shirt)
@@ -334,8 +350,8 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 
 - **Swag**: An API Platform surprise gift
 - **Requirements**: Create at least 3 PRs to [API Platform repositories](https://github.com/api-platform) during October.
-- **How to sign up**: Not clarified by now.
-- **Notes**: See this announcement from [Kévin Dunglas on his Blog](https://dunglas.fr/2019/09/api-platform-2-5-revamped-admin-new-api-testing-tool-next-js-and-quasar-app-generators-patch-and-json-schema-support-improved-openapi-and-graphql-support/).
+- **How to sign up**: Complete 3 PRs and [sign up here](https://cooptilleuls.typeform.com/to/CG0pLd).
+- **Notes**: See this announcement from [the companies website](https://les-tilleuls.coop/fr/blog/article/celebrate-hacktoberfest-with-api-platform).
 
 #### **Operation Code**
 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Not clarified by now.
 - **Notes**: See the [blog post](https://blog.mayadata.io/mayadata-celebrates-hacktoberfest-2019) and [official site](https://mayadata.io/hacktoberfest) for more information.
 
+#### **Operation Code**
+
+- **Swag**: Stickers, T-shirt.
+- **Requirements**: Resolve 3 issues (for the t-shirt) or merge 2 pull requests (for the stickers) in any one of the Operation Code repositories.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSdZAC98DQS7DW1NJT0FrHYTI-88ST6_v8gMlILankqJG295DA/viewform).
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
+
 #### **Opsdroid**
 
 - **Swag**: Stickers, Limited-Edition Stickers
@@ -298,6 +305,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Not clarified by now.
 - **Notes**: See this announcement from [Kévin Dunglas on his Blog](https://dunglas.fr/2019/09/api-platform-2-5-revamped-admin-new-api-testing-tool-next-js-and-quasar-app-generators-patch-and-json-schema-support-improved-openapi-and-graphql-support/).
 
+#### **Operation Code**
+
+- **Requirements**: Merge 2 pull requests in any one of the Operation Code repositories.
+- **Swag**: Stickers.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSdZAC98DQS7DW1NJT0FrHYTI-88ST6_v8gMlILankqJG295DA/viewform).
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
+
 #### **Twilio (Stickers and Socks)**
 
 - **Swag**: Stickers, Twilio Socks
@@ -330,6 +344,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Swag**: limited edition stickers and t-shirt
 - **How to sign up**: Make pull requests on the participating repositories and respond to us when asked for shipping details.
 - **Notes**: Check out the [official page](https://www.accordproject.org/events/hacktoberfest-2019/) for more information.
+
+#### **Operation Code**
+
+- **Requirements**: Resolve 3 issues in any one of the Operation Code repositories.
+- **Swag**: T-shirt.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSdZAC98DQS7DW1NJT0FrHYTI-88ST6_v8gMlILankqJG295DA/viewform).
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
 
 #### **Parity** (Limited Edition Parity Gym Bag)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,15 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 
 ### L
 
+#### **LBRY**
+
+- **Swag**: Sticker, LBRY t-shirt*, and more
+- **Requirements**:
+  - Contribution anything at all will receive a LBRY sticker.
+  - Contributes anything of any substance* will receive a sticker, LBRY t-shirt, and more.
+- **How to sign up**: PR to LBRY repos.
+- **Notes**: See this announcement from [Jeremy Kauffman's blog post](https://lbry.com/news/hacktoberfest-2019) and read [how to contribute](https://lbry.tech/contribute)
+
 #### **Les-Tilleuls.coop**
 
 - **Swag**: An API Platform surprise gift
@@ -180,6 +189,14 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Swag**: Sticker Pack
 - **How to sign up**: Make a PR on any of these: [The Hasura GraphQL Engine](https://github.com/hasura/graphql-engine) and/or [The GraphQL Tutorial Series](https://github.com/hasura/learn-graphql)
 - **Notes**: See the [blog post](https://blog.hasura.io/hasura-joins-hacktoberfest-2019/) for more information and keep updated at Hasura [twitter](https://twitter.com/hasurahq)
+
+#### **LBRY** (Sticker, LBRY t-shirt*, and more)
+
+- **Requirements**:
+  - Contribution anything at all will receive a LBRY sticker.
+  - Contributes anything of any substance* will receive a sticker, LBRY t-shirt, and more.
+- **How to sign up**: PR to LBRY repos.
+- **Notes**: See this announcement from [Jeremy Kauffman's blog post](https://lbry.com/news/hacktoberfest-2019) and read [how to contribute](https://lbry.tech/contribute)
 
 #### **Valor Software** (Pen and Sticker)
 

--- a/README.md
+++ b/README.md
@@ -84,6 +84,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 
 ### L
 
+#### LadybugTools
+
+- **Swag**: Sticker
+- **Requirements**: Contribute 1 or more PRs to any [hacktoberfest labelled issues](https://github.com/orgs/ladybug-tools/projects/2).
+- **How to sign up**: LadyBug will get in contact with you through your PR.
+- **Notes**: To get more information, see the [LadyBug blog post](https://discourse.ladybug.tools/t/celebrate-hacktoberfest-2019-with-ladybug-tools/7314)
+
 #### **LBRY**
 
 - **Swag**: Sticker, LBRY t-shirt*, and more
@@ -205,6 +212,13 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Swag**: Sticker Pack
 - **How to sign up**: Make a PR on any of these: [The Hasura GraphQL Engine](https://github.com/hasura/graphql-engine) and/or [The GraphQL Tutorial Series](https://github.com/hasura/learn-graphql)
 - **Notes**: See the [blog post](https://blog.hasura.io/hasura-joins-hacktoberfest-2019/) for more information and keep updated at Hasura [twitter](https://twitter.com/hasurahq)
+
+#### LadybugTools
+
+- **Swag**: Sticker
+- **Requirements**: Contribute 1 or more PRs to any [hacktoberfest labelled issues](https://github.com/orgs/ladybug-tools/projects/2).
+- **How to sign up**: LadyBug will get in contact with you through your PR.
+- **Notes**: To get more information, see the [LadyBug blog post](https://discourse.ladybug.tools/t/celebrate-hacktoberfest-2019-with-ladybug-tools/7314)
 
 #### **LBRY** (Sticker, LBRY t-shirt*, and more)
 


### PR DESCRIPTION
I just learned some new information about Les-Tilleuls.coop participation in Hacktoberfest. So I added the sign up link and corrected to blog post to the companies official statement rather than the Owners personal blog as promised in https://github.com/crweiner/hacktoberfest-swag-list/pull/82#issuecomment-537090099.