### PR TITLE
Add Operation Code to Swag List

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -136,6 +136,7 @@ If your contribution or PR is not formatted correctly, I'll let you know and giv
 - [Sourav Roy](https://github.com/souravroy-test/)
 - [David Ma](https://github.com/Taikon/)
 - [Khushi](https://github.com/khushijindal/)
+- [Rohit Mathew](https://github.com/rohitjmathew)
 
 Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/) or any company offering swag.
 

--- a/README.md
+++ b/README.md
@@ -124,6 +124,16 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest)
 - **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata).
 
+### O
+
+#### **Operation Code**
+
+- **Swag**: Stickers and T-shirt.
+- **Requirements**: Resolve 3 issues (for the T-shirt) or merge 2 pull requests (for the stickers) in any one of the Operation Code repositories.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
+- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3AOperationCode+label%3Ahacktoberfest+type:issue&state=open&type=Issues)
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
+
 ### V
 
 #### **Vonage/Nexmo**
@@ -233,6 +243,20 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **Swag**: T-shirt, stickers
 - **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS) and we'll send you a link.
 - **Notes**: Check out our [contributing guide](https://docs.lakefs.io/contributing) and join our [slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw) for help and discussions
+
+#### **Operation Code** (Stickers)
+
+- **Requirements**: Merge 2 pull requests in any one of the Operation Code repositories.
+- **Swag**: Stickers.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
+
+#### **Operation Code** (T-shirt)
+
+- **Requirements**: Resolve 3 issues in any one of the Operation Code repositories.
+- **Swag**: T-shirt.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
 
 ### 5 or more Merged PRs
 

--- a/README.md
+++ b/README.md
@@ -319,18 +319,12 @@ See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull requ
 - **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS) and we'll send you a link.
 - **Notes**: Check out our [contributing guide](https://docs.lakefs.io/contributing) and join our [slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw) for help and discussions
 
-
 #### **Operation Code** (Stickers)
 
-- **Requirements**: Merge 2 pull requests in any one of the Operation Code repositories.
-- **Swag**: Stickers.
-- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
-- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
-
-#### **Operation Code** (T-shirt)
-
-- **Requirements**: Resolve 3 issues in any one of the Operation Code repositories.
-- **Swag**: T-shirt.
+- **Requirements**:
+  - Merge 2+ PRs in any one of the Operation Code repositoris: Stickers
+  - Resolve 3 issues in any one of the Operation Code repositories: T-shirt
+- **Swag**: Stickers and/or T-shirt
 - **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
 - **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
 


### PR DESCRIPTION
This commit adds Operation Code details to the swag list in both A-Z and in involvements section

Thanks for contributing to the [Hacktoberfest Swag List](https://hacktoberfestswaglist.com/) :smiley: :tada:! Before submitting your pull request, please check off as many of the items below as you can:

1. [x] I have read the [Contributing.md](../CONTRIBUTING.md) file and formatted this PR correctly
2. [x] I'm not adding a company from the blocklist
3. [x] I make sure to fix things promptly if an error or suggestion comes up

Thanks and Happy Hacktoberfest! :tada:
Tagging @crweiner to take a look. :eyes:

Closes #291 