### PR TITLE
Revert "Setting links to open in a new tab (I believe this is normal behavior on sites)"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,7 +36,7 @@ Find the first letter of your company within the list, then add your information
 
 - **Swag**: (T-shirt, stickers, etc)
 - **Requirements**: (What do I have to complete? Are there different requirements per swag item? Are the PRs merged or just submitted?)
-- **How to sign up**: (Link to signup page using inline formatting of [text](URL){:target="_blank"})
+- **How to sign up**: (Link to signup page using inline formatting of [text](URL))
 - **Issues**: Optional (link to Hacktoberfest tagged issues)
 - **Notes**: (If needed, otherwise write N/A)
 ```
@@ -74,7 +74,7 @@ This section of the list will follow a slightly different set of formatting in o
 - **Requirements**: If the company only offers one type of swag, then state the requirements here
   - If they offer multiple levels of swag, then record this particular swag item here as an indented bullet point
 - **Swag**: (T-shirt, stickers, etc)
-- **How to sign up**: (Link to signup page using inline formatting of [text](URL){:target="_blank"})
+- **How to sign up**: (Link to signup page using inline formatting of [text](URL))
  **Issues**: Optional (link to Hacktoberfest tagged issues)
 - **Notes**: (If needed, otherwise write N/A)
 ```

--- a/README.md
+++ b/README.md
@@ -6,10 +6,10 @@ This repo seeks to document all of the companies giving away swag for Hacktoberf
 
 ## Hacktoberfest is about making meaningful contributions to open source projects. SPAM for the sake of a T-shirt will not be tolerated
 
-First, [sign up for Hacktoberfest 2020 by clicking this link](https://hacktoberfest.digitalocean.com/) Then, [read about how to participate in a meaningful way](https://hacktoberfest.digitalocean.com/details/){:target="_blank"}.
+First, [sign up for Hacktoberfest 2020 by clicking this link](https://hacktoberfest.digitalocean.com/) Then, [read about how to participate in a meaningful way](https://hacktoberfest.digitalocean.com/details/).
 
-See [**Contributing.md**](./CONTRIBUTING.md){:target="_blank"} to see how to format your pull request to add a company's swag to the List!
-For more information regarding this click [here](https://hacktoberfest.digitalocean.com/hacktoberfest-update){:target="_blank"}.
+See [**Contributing.md**](./CONTRIBUTING.md) to see how to format your pull request to add a company's swag to the List!
+For more information regarding this click [here](https://hacktoberfest.digitalocean.com/hacktoberfest-update).
 
 ## Quick Jump To
 
@@ -23,9 +23,9 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 ### **The Original - DigitalOcean, Intel, and DEV**
 
 - **Swag**: T-shirt, stickers
-- **Requirements**: 4 pull requests in any eligible [repository](https://github.com/topics/hacktoberfest){:target="_blank"}
-- **How to sign up**: [Hacktoberfest Website](https://hacktoberfest.digitalocean.com){:target="_blank"}
-- **Notes**: Please see [updates for repo eligibiliy and a statent from Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update){:target="_blank"}. For your PR to count it must be:
+- **Requirements**: 4 pull requests in any eligible [repository](https://github.com/topics/hacktoberfest)
+- **How to sign up**: [Hacktoberfest Website](https://hacktoberfest.digitalocean.com)
+- **Notes**: Please see [updates for repo eligibiliy and a statent from Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update). For your PR to count it must be:
   - Submitted in a repo labeled ```hacktoberfest``` AND
   - Merged, OR
   - Labelled ```hacktoberfest-accepted```  by a maintainer, OR
@@ -38,35 +38,35 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 #### **Activeloop**
 
 - **Swag**: Sony noise-cancelling headphones, T-Shirt, stickers and face mask
-- **Requirements**: Create one or more merged pull requests on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub){:target="_blank"}.
+- **Requirements**: Create one or more merged pull requests on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub).
   - 1 or more merged PR: stickers
   - 3 or more merged PRs: T-shirt plus a choice of stickers or face mask
   - 5 or more  merged PRs: T-shirt, stickers, and a face mask
   - Top Contributor Award: SONY WH-CH710 noise-cancelling headphones
-- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md){:target="_blank"} before making pull requests.
+- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub)
+- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest) or any issue you like to help with.
+- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md) before making pull requests.
 
 #### **Appsmith**
 
 - **Swag**: T-Shirt, stickers, WASD Keyboard
-- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith){:target="_blank"}.
+- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith).
   - 1+ merged PR: Stickers
   - 3+ merged PR: T-Shirt
   - Top contributor Referral: WASD Keyboard.
-- **How to sign up**: Raise a PR and join us on discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp){:target="_blank"} for more information and help.
+- **How to sign up**: Raise a PR and join us on discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863)
+- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest) or any issue you like to help with.
+- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp) for more information and help.
 
 #### **Appwrite**
 
 - **Swag**: T-Shirt, stickers, magnets, and buttons.
-- **Requirements**: Create one or more merged pull requests on any of [Appwrite repos](https://github.com/appwrite){:target="_blank"}.
+- **Requirements**: Create one or more merged pull requests on any of [Appwrite repos](https://github.com/appwrite).
   - 1+ merged PR: Stickers, magnets, and buttons
   - Top contributors: Appwrite T-Shirt.
-- **How to sign up**: Make a PR on any of [Appwrite GitHub Repos](https://github.com/appwrite){:target="_blank"} and they'll send you a link.
-- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3Aappwrite+label%3Ahacktoberfest+type:issue&state=open&type=Issues){:target="_blank"} or any issue you like to help with.
-- **Notes**: Follow [Appwrite blog](https://medium.com/appwrite-io) and [Discord community](https://appwrite.io/discord){:target="_blank"} for more information and help.
+- **How to sign up**: Make a PR on any of [Appwrite GitHub Repos](https://github.com/appwrite) and they'll send you a link.
+- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3Aappwrite+label%3Ahacktoberfest+type:issue&state=open&type=Issues) or any issue you like to help with.
+- **Notes**: Follow [Appwrite blog](https://medium.com/appwrite-io) and [Discord community](https://appwrite.io/discord) for more information and help.
 
 #### **AquaSecurity**
 
@@ -75,20 +75,20 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - 1+ merged PR: stickers or face mask
   - 3+ merged PRs: T-shirt plus a choice of stickers or face mask
   - 5+ merged PRs: T-shirt, stickers, and a face mask
-  - Top 3 Contributors: [Kubernetes Security Book](https://www.oreilly.com/library/view/kubernetes-security/9781492039075/) signed by [Liz Rice](https://www.lizrice.com/){:target="_blank"}.
-- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u){:target="_blank"}. The projects are:
-  - [kube-bench](https://github.com/aquasecurity/kube-bench){:target="_blank"}
-  - [Trivy](https://github.com/aquasecurity/Trivy){:target="_blank"}
-  - [Tracee](https://github.com/aquasecurity/tracee){:target="_blank"}
-  - [Starboard](https://github.com/aquasecurity/Starboard){:target="_blank"}
-  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter){:target="_blank"}
-- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest){:target="_blank"} for more information and contribution guide.
+  - Top 3 Contributors: [Kubernetes Security Book](https://www.oreilly.com/library/view/kubernetes-security/9781492039075/) signed by [Liz Rice](https://www.lizrice.com/).
+- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u). The projects are:
+  - [kube-bench](https://github.com/aquasecurity/kube-bench)
+  - [Trivy](https://github.com/aquasecurity/Trivy)
+  - [Tracee](https://github.com/aquasecurity/tracee)
+  - [Starboard](https://github.com/aquasecurity/Starboard)
+  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter)
+- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest) for more information and contribution guide.
 
 #### **ArchivesSpace**
 
 - **Swag**: ArchivesSpace swag bag
 - **Requirements**: Be the contributor with the most merged PRs.
-- **How to sign up**: Make PRs on [ArchivesSpace Github](https://github.com/archivesspace/archivesspace){:target="_blank"} and the top contributor will win the bag.
+- **How to sign up**: Make PRs on [ArchivesSpace Github](https://github.com/archivesspace/archivesspace) and the top contributor will win the bag.
 - **Notes**: Check out [ArchivesSpace Hacktoberfest 2020
  blog](https://archivesspace.org/archives/6563) for more information.
 
@@ -98,8 +98,8 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: T-shirt, stickers
 - **Requirements**: 2 or more merged PRs
-- **How to sign up**: Submit two PRs then let them know you’ve completed the challenge by filling out the form on their [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/) and they will send you an e-mail. The repos are: [Camunda BPM](https://github.com/camunda/), [bpmn.io](https://github.com/bpmn-io/), and [Zeebe-io](https://github.com/zeebe-io/){:target="_blank"}.
-- **Notes**: Check out Camunda [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/){:target="_blank"} for more info & how to get the T-shirt.
+- **How to sign up**: Submit two PRs then let them know you’ve completed the challenge by filling out the form on their [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/) and they will send you an e-mail. The repos are: [Camunda BPM](https://github.com/camunda/), [bpmn.io](https://github.com/bpmn-io/), and [Zeebe-io](https://github.com/zeebe-io/).
+- **Notes**: Check out Camunda [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/) for more info & how to get the T-shirt.
 
 #### **CircleCI**
 
@@ -110,24 +110,24 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - Develop one new Orb and get all of the stuff plus a Magic Pin
 - **How to sign up**:
   - Challenge 1: Complete a merged or accepted PR to include orb usage on an existing CircleCI config
-  - Challenge 2: Develop and publish an orb using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit){:target="_blank"}. Make sure your orb offers value to other developers!
-  - After you are done with any one of the two challenges use [this](https://circleci-community.typeform.com/to/mErGL0nv){:target="_blank"} form to enter you PRs.
-- **Notes**: Check out the official website of CircleCI [here](https://hacktoberfest.circleci.com/){:target="_blank"}. PRs must either be merged or tagged with the "Orbtoberfest" label to count.
+  - Challenge 2: Develop and publish an orb using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit). Make sure your orb offers value to other developers!
+  - After you are done with any one of the two challenges use [this](https://circleci-community.typeform.com/to/mErGL0nv) form to enter you PRs.
+- **Notes**: Check out the official website of CircleCI [here](https://hacktoberfest.circleci.com/). PRs must either be merged or tagged with the "Orbtoberfest" label to count.
 
 #### **Commerce.js**
 
 - **Swag**: Commerce.js swag bundle
 - **Requirements**: 1 merged PR
-- **How to sign up**: There are many issues with the [#hacktoberfest](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+) tag or view more ways to contribute and fill out the form [here](https://commercejs.com/docs/hacktoberfest/){:target="_blank"}.
-- **Issues**: [Commerce.js](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+){:target="_blank"}
-- **Notes**: For more details visit the [contributing guidelines](https://commercejs.com/docs/community/contribute) and dedicated [Hacktoberfest page](https://commercejs.com/docs/hacktoberfest/){:target="_blank"} to get involved.
+- **How to sign up**: There are many issues with the [#hacktoberfest](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+) tag or view more ways to contribute and fill out the form [here](https://commercejs.com/docs/hacktoberfest/).
+- **Issues**: [Commerce.js](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+)
+- **Notes**: For more details visit the [contributing guidelines](https://commercejs.com/docs/community/contribute) and dedicated [Hacktoberfest page](https://commercejs.com/docs/hacktoberfest/) to get involved.
 
 #### **Crio**
 
 - **Swag**: Crio bag of goodies, t-shirt, and up to 50% scholarship
 - **Requirements**: Top 50 performers
-- **How to sign up**: Fill out the form [here](https://crio.do/IBelieveInDoing/October/){:target="_blank"}.
-- **Notes**: For more details, visit the dedicated [Hacktoberfest page](https://crio.do/IBelieveInDoing/October/){:target="_blank"} to get involved. Only eligible contributors residing in India will be shipped stickers and those making top 50 contributors will be shipped exclusive goodies, including a t-shirt.
+- **How to sign up**: Fill out the form [here](https://crio.do/IBelieveInDoing/October/).
+- **Notes**: For more details, visit the dedicated [Hacktoberfest page](https://crio.do/IBelieveInDoing/October/) to get involved. Only eligible contributors residing in India will be shipped stickers and those making top 50 contributors will be shipped exclusive goodies, including a t-shirt.
 
 ### D
 
@@ -135,40 +135,40 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: At least 3 stickers and maybe a T-shirt
 - **Requirements**:
-  - Eligible repositories include most repos of the Datenanfragen organization. They are listed [here](https://www.datarequests.org/blog/hacktoberfest-2020/#repos){:target="_blank"}
+  - Eligible repositories include most repos of the Datenanfragen organization. They are listed [here](https://www.datarequests.org/blog/hacktoberfest-2020/#repos)
   - 1 merged pull request to get at least 3 stickers (limited to 100 sets)
   - T-shirts are given to 10 people drawn from the contributors
-- **How to sign up**: Submit to the repositories either via PR on GitHub or via patch file by email and register using the [webform](https://www.datarequests.org/blog/hacktoberfest-2020){:target="_blank"} before November 4, 2020.
-- **Issues**: [datenanfragen](https://github.com/search?&q=user%3Adatenanfragen+type:issue&state=open&type=Issues){:target="_blank"}
-- **Notes**: Take a look at [this blog post](https://www.datarequests.org/blog/hacktoberfest-2020/){:target="_blank"} for more info.
+- **How to sign up**: Submit to the repositories either via PR on GitHub or via patch file by email and register using the [webform](https://www.datarequests.org/blog/hacktoberfest-2020) before November 4, 2020.
+- **Issues**: [datenanfragen](https://github.com/search?&q=user%3Adatenanfragen+type:issue&state=open&type=Issues)
+- **Notes**: Take a look at [this blog post](https://www.datarequests.org/blog/hacktoberfest-2020/) for more info.
 
 #### **Devfolio**
 
 - **Swag**: Stickers, t-shirt (limited to top 50 contributors)
 - **Requirements**: 4+ merged PRs
 - **How to sign up**: Contribute to any of the following GitHub repositories:
-  - [react-otp-input](https://github.com/devfolioco/react-otp-input){:target="_blank"}
-  - [react-copy-mailto](https://github.com/devfolioco/react-copy-mailto){:target="_blank"}
-  - [scrroll-in](https://github.com/devfolioco/scrroll-in){:target="_blank"}
-  - [devfolio-gatsby-starter](https://github.com/devfolioco/devfolio-gatsby-starter){:target="_blank"}.
-  - Fill out the [form](https://forms.gle/cp3EcPWzwyqW8fc68){:target="_blank"} before November 1st.
-- **Notes**: For more info visit [Devfolio's Hacktoberfest page](https://devfolio.co/blog/devfolio-hacktoberfest-2020). Only eligible contributors residing in India will be shipped stickers (including a limited edition Devfolio Hacktoberfest ones) and those making top 50 contributors will be shipped an exclusive t-shirt (within India only){:target="_blank"}.
+  - [react-otp-input](https://github.com/devfolioco/react-otp-input)
+  - [react-copy-mailto](https://github.com/devfolioco/react-copy-mailto)
+  - [scrroll-in](https://github.com/devfolioco/scrroll-in)
+  - [devfolio-gatsby-starter](https://github.com/devfolioco/devfolio-gatsby-starter).
+  - Fill out the [form](https://forms.gle/cp3EcPWzwyqW8fc68) before November 1st.
+- **Notes**: For more info visit [Devfolio's Hacktoberfest page](https://devfolio.co/blog/devfolio-hacktoberfest-2020). Only eligible contributors residing in India will be shipped stickers (including a limited edition Devfolio Hacktoberfest ones) and those making top 50 contributors will be shipped an exclusive t-shirt (within India only).
 
 #### **DX Heroes**
 
 - **Swag**: T-shirt, stickers, notebook, bottle opener
 - **Requirements**: Be the contributor with the most merged PRs.
-- **How to sign up**: Please, fill out this [DX Heroes Hacktoberfest2020 Participant Form](https://forms.gle/o3sBqsjr4sYLQgPh6) first. Then just visit one of the open source projects - [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content) or [DX Scanner](https://github.com/DXHeroes/dx-scanner){:target="_blank"}, make a pull request and compete with other contributors in the friendly competition to earn your place in the Leaderboard of Contributors.
-- **Notes**: If you have any questions or need help with anything, join the [Community Slack](https://bit.ly/slack_developer_experience){:target="_blank"}. We will gladly help you. Happy Hacktoberfest 2020!
+- **How to sign up**: Please, fill out this [DX Heroes Hacktoberfest2020 Participant Form](https://forms.gle/o3sBqsjr4sYLQgPh6) first. Then just visit one of the open source projects - [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content) or [DX Scanner](https://github.com/DXHeroes/dx-scanner), make a pull request and compete with other contributors in the friendly competition to earn your place in the Leaderboard of Contributors.
+- **Notes**: If you have any questions or need help with anything, join the [Community Slack](https://bit.ly/slack_developer_experience). We will gladly help you. Happy Hacktoberfest 2020!
 
 ### E
 
 #### **Earthly**
 
 - **Swag**: Stickers (limit 40)
-- **Requirements**: Contribute code to the [Earthly](https://github.com/earthly/earthly){:target="_blank"} open source build tool or contribute an Earthfile build to any public repo.
-- **How to sign up**: [Grab an issue](https://github.com/earthly/earthly/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest) and after completion we they reach out to you to get your mailing address or reach out to adam@earthly.dev via email to claim your sticker.  If you aren't sure what to work on, [Let's chat](https://gitter.im/earthly-room/community){:target="_blank"}
-- **Notes**: If you have any questions or need help with anything, join the [Community Gitter Channel]( https://gitter.im/earthly-room/community). They'll gladly help you. See the [blog post](https://blog.earthly.dev/hacktoberfest-2020/){:target="_blank"} for more details.
+- **Requirements**: Contribute code to the [Earthly](https://github.com/earthly/earthly) open source build tool or contribute an Earthfile build to any public repo.
+- **How to sign up**: [Grab an issue](https://github.com/earthly/earthly/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest) and after completion we they reach out to you to get your mailing address or reach out to adam@earthly.dev via email to claim your sticker.  If you aren't sure what to work on, [Let's chat](https://gitter.im/earthly-room/community)
+- **Notes**: If you have any questions or need help with anything, join the [Community Gitter Channel]( https://gitter.im/earthly-room/community). They'll gladly help you. See the [blog post](https://blog.earthly.dev/hacktoberfest-2020/) for more details.
 
 ### G
 
@@ -178,8 +178,8 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - Contribute to two pull requests in any Globo Open Source project during the month of October.
   - Ensure that at least one pull request is merged.
-- **How to sign up**: Make two PRs to any of Globo's open-source projects – [Globo Home](https://github.com/globocom){:target="_blank"}
-- **Notes**: Only the first 100 people residing in Brazil will receive the t-shirt. Read their [Hacktoberfest page here](https://opensource.globo.com/hacktoberfest/){:target="_blank"}
+- **How to sign up**: Make two PRs to any of Globo's open-source projects – [Globo Home](https://github.com/globocom)
+- **Notes**: Only the first 100 people residing in Brazil will receive the t-shirt. Read their [Hacktoberfest page here](https://opensource.globo.com/hacktoberfest/)
 
 ### H
 
@@ -190,14 +190,14 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - 1+ merged PR with the label hacktoberfest: T-shirt/Mask/Pin
   - 1+ merged PR with a small fix, such as typo: Stickers
 - **How to sign up**: Submit a PR to any of the following repositories:
-  - [GraphQL Engine](https://github.com/hasura/graphql-engine){:target="_blank"}
-  - [Learn GraphQL](https://github.com/hasura/learn-graphql){:target="_blank"}
+  - [GraphQL Engine](https://github.com/hasura/graphql-engine)
+  - [Learn GraphQL](https://github.com/hasura/learn-graphql)
 - **Notes**:
   - If you have any questions or need help with anything, available options:
-  - Open a [Github Discussion](https://github.com/hasura/graphql-engine/discussions){:target="_blank"}, if the question is not already posted.
-  - #contrib channel on [Discord server](http://hasura.io/discord){:target="_blank"}
-  - [Tweet](https://twitter.com/HasuraHQ){:target="_blank"}
-  - Guidelines available at: [Guidelines](https://hasura.io/blog/hasura-joins-hacktoberfest-3rd-year-in-a-row){:target="_blank"}
+  - Open a [Github Discussion](https://github.com/hasura/graphql-engine/discussions), if the question is not already posted.
+  - #contrib channel on [Discord server](http://hasura.io/discord)
+  - [Tweet](https://twitter.com/HasuraHQ)
+  - Guidelines available at: [Guidelines](https://hasura.io/blog/hasura-joins-hacktoberfest-3rd-year-in-a-row)
 
 ### I
 
@@ -206,13 +206,13 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Swag**: Sweatshirt
 - **Requirements**: 2+ merged PR
 - **How to sign up**: Eligible Indeed repos:
-  - [k8dash](https://github.com/indeedeng/k8dash){:target="_blank"}
-  - [starfish](https://github.com/indeedeng/starfish){:target="_blank"}
-  - [FasterXML/jackson](https://github.com/FasterXML/jackson){:target="_blank"}
-  - [deps.cloud](https://github.com/depscloud/depscloud){:target="_blank"}
-  - [Mariner](https://github.com/indeedeng/mariner){:target="_blank"}
-  - Create two or more merged PRs and then [fill this form](https://docs.google.com/forms/d/e/1FAIpQLSeUKDE1fdyG3jRBngj0dnAXIEKscO128rrXw3a1BcFwNQ6iHg/viewform){:target="_blank"} to get your swag.
-- **Notes**: Shipping only in the US. Check this out [Indeed blog](https://engineering.indeedblog.com/indeed-hacktoberfest-2020/){:target="_blank"} for more information and help.
+  - [k8dash](https://github.com/indeedeng/k8dash)
+  - [starfish](https://github.com/indeedeng/starfish)
+  - [FasterXML/jackson](https://github.com/FasterXML/jackson)
+  - [deps.cloud](https://github.com/depscloud/depscloud)
+  - [Mariner](https://github.com/indeedeng/mariner)
+  - Create two or more merged PRs and then [fill this form](https://docs.google.com/forms/d/e/1FAIpQLSeUKDE1fdyG3jRBngj0dnAXIEKscO128rrXw3a1BcFwNQ6iHg/viewform) to get your swag.
+- **Notes**: Shipping only in the US. Check this out [Indeed blog](https://engineering.indeedblog.com/indeed-hacktoberfest-2020/) for more information and help.
 
 #### **IBM**
 
@@ -221,9 +221,9 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - An IBM employee.
   - Complete annual OSPG training/certification (if not completed already).
   - Submit four (or more) valid pull requests during the month of October. However, you'll be eligible for the badge upon submitting your first PR.
-- **How to sign up**: Submit your PR links before October 31, 2020 on [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (you'll need to be in IBM VPN){:target="_blank"}.
+- **How to sign up**: Submit your PR links before October 31, 2020 on [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (you'll need to be in IBM VPN).
 - **Issues**: Any open source issues that may not be considered as conflict of interest.
-- **Notes**: Only first 250 IBMers are eligible for the developer swag. Refer to [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (IBM VPN needed){:target="_blank"} for complete guidelines/requirements.
+- **Notes**: Only first 250 IBMers are eligible for the developer swag. Refer to [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (IBM VPN needed) for complete guidelines/requirements.
 
 #### **InfraCloud**
 
@@ -231,8 +231,8 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - 1+ merged PR: T-shirt and Stickers
   - Top Contributor: Kindle
-- **How to sign up**: Make a PR or more on InfraCloud's open-source projects – [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube). To deliver the swags, they will reach out to you once PR(s){:target="_blank"} gets merged.
-- **Notes**: Only the first 50 people will receive the swags. A person with maximum merged PRs will also get a Kindle. Check out InfraCloud [official page](https://www.infracloud.io/infracloud-joins-hacktoberfest-2020/) for more info and join [Fission’s Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE) and [BotKube’s Slack](http://join.botkube.io/){:target="_blank"}.
+- **How to sign up**: Make a PR or more on InfraCloud's open-source projects – [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube). To deliver the swags, they will reach out to you once PR(s) gets merged.
+- **Notes**: Only the first 50 people will receive the swags. A person with maximum merged PRs will also get a Kindle. Check out InfraCloud [official page](https://www.infracloud.io/infracloud-joins-hacktoberfest-2020/) for more info and join [Fission’s Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE) and [BotKube’s Slack](http://join.botkube.io/).
 
 ### J
 
@@ -240,8 +240,8 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: Access to all professional developer tools for 3 months, plus 20% off an annual subscription.
 - **Requirements**: 4+ submitted PR's.
-- **How to sign up**: Please fill out this [Get your Hacktoberfest participant perks from JetBrains](https://www.jetbrains.com/lp/hacktoberfest-2020/#get-the-tools){:target="_blank"} form and then make four quality pull requests to public GitHub repositories. Once you register by filling out the form, you will get a 3 month subscription to their professional tools to use after Hacktoberfest!
-- **Notes**: You can contact them by sending email to marketing@jetbrains.com and by joining [Discord](https://discord.com/invite/hacktoberfest). You can read more about them [here](https://www.jetbrains.com/lp/hacktoberfest-2020/){:target="_blank"}.
+- **How to sign up**: Please fill out this [Get your Hacktoberfest participant perks from JetBrains](https://www.jetbrains.com/lp/hacktoberfest-2020/#get-the-tools) form and then make four quality pull requests to public GitHub repositories. Once you register by filling out the form, you will get a 3 month subscription to their professional tools to use after Hacktoberfest!
+- **Notes**: You can contact them by sending email to marketing@jetbrains.com and by joining [Discord](https://discord.com/invite/hacktoberfest). You can read more about them [here](https://www.jetbrains.com/lp/hacktoberfest-2020/).
 
 ### L
 
@@ -251,15 +251,15 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - 1+ merged PR: Stickers
   - 2+ merged PRs: Stickers and a lakeFS t-shirt
-- **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS){:target="_blank"} and they'll send you a link.
-- **Notes**: Check out the [contributing guide](https://docs.lakefs.io/contributing) and join the [Slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw){:target="_blank"} for help and discussions
+- **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS) and they'll send you a link.
+- **Notes**: Check out the [contributing guide](https://docs.lakefs.io/contributing) and join the [Slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw) for help and discussions
 
 #### **LoginRadius**
 
 - **Swag**: T-Shirt, stickers
-- **Requirements**: Make one successful pull request in October 2020 to any open source [LoginRadius repository](https://github.com/LoginRadius){:target="_blank"} and earn a T-shirt and Swags!
-- **How to sign up**: Fill the [form](https://forms.gle/aUYJXoVJVivPgGuM8) and make a successful PR on any of [LoginRadius repository](https://github.com/LoginRadius){:target="_blank"}.
-- **Notes**: Keep in touch from our [LoginRadius Engineering Blog](https://www.loginradius.com/engineering/page/hacktoberfest2020){:target="_blank"} site for more updates.
+- **Requirements**: Make one successful pull request in October 2020 to any open source [LoginRadius repository](https://github.com/LoginRadius) and earn a T-shirt and Swags!
+- **How to sign up**: Fill the [form](https://forms.gle/aUYJXoVJVivPgGuM8) and make a successful PR on any of [LoginRadius repository](https://github.com/LoginRadius).
+- **Notes**: Keep in touch from our [LoginRadius Engineering Blog](https://www.loginradius.com/engineering/page/hacktoberfest2020) site for more updates.
 
 ### M
 
@@ -267,8 +267,8 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: Mug
 - **Requirements**: 1+ merged PR
-- **How to sign up**: Create one or more PR(s) on [Mattermost featured projects](https://mattermost.com/hacktoberfest/). If you contribute to Mattermost and it’s your first time contributing, you’ll also [earn some swag](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143/6){:target="_blank"} from them!
-- **Notes**: Check out the [Mattermost Hacktoberfest blog](https://mattermost.com/blog/hacktoberfest-2020/) for more information and read the [contribution guidelines](https://developers.mattermost.com/contribute/getting-started/){:target="_blank"} about how to contribute.
+- **How to sign up**: Create one or more PR(s) on [Mattermost featured projects](https://mattermost.com/hacktoberfest/). If you contribute to Mattermost and it’s your first time contributing, you’ll also [earn some swag](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143/6) from them!
+- **Notes**: Check out the [Mattermost Hacktoberfest blog](https://mattermost.com/blog/hacktoberfest-2020/) for more information and read the [contribution guidelines](https://developers.mattermost.com/contribute/getting-started/) about how to contribute.
 
 #### **MayaData**
 
@@ -276,17 +276,17 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - 1+ merged PR: T-shirt and sticker
   - Top contributors: Laptop, mechanical keyboard, NVMe Drive or wireless earbuds
-- **How to sign up**: Fill form from the link you will receive once your PR is merged. PR can be from [OpenEBS](https://github.com/openebs/openebs) or [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest){:target="_blank"}.
-- **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest){:target="_blank"}
-- **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata){:target="_blank"}.
+- **How to sign up**: Fill form from the link you will receive once your PR is merged. PR can be from [OpenEBS](https://github.com/openebs/openebs) or [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest).
+- **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest)
+- **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata).
 
 #### **Meedan**
 
 - **Swag**: T-shirt, stickers, mask
-- **Requirements**: 1+ merged PRs on any of the services that support the [Check platform](https://github.com/meedan/check){:target="_blank"}
+- **Requirements**: 1+ merged PRs on any of the services that support the [Check platform](https://github.com/meedan/check)
 - **How to sign up**: Make one PR or more on any Check's open source services. After the PR(s) gets merged we will reach out to you to get shipping information.
-- **Issues**: [Check issues](https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest){:target="_blank"}
-- **Notes**: Check out [Meedan's Hacktoberfest page](https://meedan.com/hacktoberfest){:target="_blank"} for more information.
+- **Issues**: [Check issues](https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest)
+- **Notes**: Check out [Meedan's Hacktoberfest page](https://meedan.com/hacktoberfest) for more information.
 
 ### O
 
@@ -294,59 +294,59 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: Stickers and T-shirt.
 - **Requirements**: Resolve 3 issues (for the T-shirt) or merge 2 pull requests (for the stickers) in any one of the Operation Code repositories.
-- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform){:target="_blank"}.
-- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3AOperationCode+label%3Ahacktoberfest+type:issue&state=open&type=Issues){:target="_blank"}
-- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE){:target="_blank"} for more information about how to contribute.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
+- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3AOperationCode+label%3Ahacktoberfest+type:issue&state=open&type=Issues)
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
 
 ### P
 
 #### **Parabeac-Core**
 
 - **Swag**: T-shirt.
-- **Requirements**: Be among the top 100 contributors on [Parabeac Core](https://github.com/Parabeac/Parabeac-Core){:target="_blank"}.
+- **Requirements**: Be among the top 100 contributors on [Parabeac Core](https://github.com/Parabeac/Parabeac-Core).
 - **How to sign up**: You will be contacted if you're among the top 100.
-- **Notes**: Check their [official post](https://dev.to/parabeac/hacktoberfest-parabeac-open-source-design-to-flutter-code-1jg0){:target="_blank"} to learn more.
+- **Notes**: Check their [official post](https://dev.to/parabeac/hacktoberfest-parabeac-open-source-design-to-flutter-code-1jg0) to learn more.
 
 ### S
 
 #### **Sensenet**
 
-- **Swag**: Sensenet special edition socks (limit 60), 10% discount code for their [business plan](https://sensenet.com/pricing){:target="_blank"}.
+- **Swag**: Sensenet special edition socks (limit 60), 10% discount code for their [business plan](https://sensenet.com/pricing).
 - **Requirements** - 1+ merged PR
-- **How to sign up**: Complete the entry challenge by [creating a sensenet content repository](https://profile.sensenet.com/?redirectToLogin) and starring [sensenet's GitHub repository](https://github.com/SenseNet/sensenet){:target="_blank"}.
-- **Notes**: Check out [sensenet's Hacktoberfest page](https://hacktoberfest.sensenet.com/). Pull requests only count if they correspond to an issue found on the [dedicated board](https://github.com/orgs/SenseNet/projects/7){:target="_blank"}.
+- **How to sign up**: Complete the entry challenge by [creating a sensenet content repository](https://profile.sensenet.com/?redirectToLogin) and starring [sensenet's GitHub repository](https://github.com/SenseNet/sensenet).
+- **Notes**: Check out [sensenet's Hacktoberfest page](https://hacktoberfest.sensenet.com/). Pull requests only count if they correspond to an issue found on the [dedicated board](https://github.com/orgs/SenseNet/projects/7).
 
 #### **Specflow**
 
 - **Swag**: Stickers
 - **Requirements**: 1+ merged PR
-- **How to sign up**: 1+ Merged PR to any [Specflow repo](https://github.com/SpecFlowOSS/SpecFlow/) and then [fill up this form](https://specflow.org/contributer-package/){:target="_blank"} to get swag.
-- **Issues**: New to Open source? Look for issues [#first-timers-only](https://github.com/SpecFlowOSS/SpecFlow/labels/first-timers-only), [Up-for-grabs](https://github.com/SpecFlowOSS/SpecFlow/labels/up-for-grabs){:target="_blank"}.
-- **Notes**: Check out [Specflow Hacktoberfest 2020 blog](https://specflow.org/blog/hacktoberfest-2020-starts-soon/3) for more information and read [the contributing guide](https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md){:target="_blank"} on how to contribute.
+- **How to sign up**: 1+ Merged PR to any [Specflow repo](https://github.com/SpecFlowOSS/SpecFlow/) and then [fill up this form](https://specflow.org/contributer-package/) to get swag.
+- **Issues**: New to Open source? Look for issues [#first-timers-only](https://github.com/SpecFlowOSS/SpecFlow/labels/first-timers-only), [Up-for-grabs](https://github.com/SpecFlowOSS/SpecFlow/labels/up-for-grabs).
+- **Notes**: Check out [Specflow Hacktoberfest 2020 blog](https://specflow.org/blog/hacktoberfest-2020-starts-soon/3) for more information and read [the contributing guide](https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) on how to contribute.
 
 #### **Stack Builders**
 
 - **Swag**: 9 gift cards
 - **Requirements**: Top contributors
-- **How to sign up**: Submit PRs to [StackBuilders GitHub](https://github.com/stackbuilders) and [fill up this form](https://docs.google.com/forms/d/e/1FAIpQLSc4QyXBUKf0nGvPdW6RaY2FJnIC45LkUsmoIZgCW6i1Jrliag/viewform){:target="_blank"}. Judges will review PRs and select the PRs depending on project size and relevance in the industry, the complexity of your contribution, the PR number and the quality code.
-- **Notes**: Check [Stackbuilders hacktoberfest blog](https://www.stackbuilders.com/news/join-us-for-our-first-hacktoberfest) for more information. Join [Stackbuilders Discord](https://discord.com/invite/S4QzFe8){:target="_blank"} to ask your doubts and talk about the event or your progress.
+- **How to sign up**: Submit PRs to [StackBuilders GitHub](https://github.com/stackbuilders) and [fill up this form](https://docs.google.com/forms/d/e/1FAIpQLSc4QyXBUKf0nGvPdW6RaY2FJnIC45LkUsmoIZgCW6i1Jrliag/viewform). Judges will review PRs and select the PRs depending on project size and relevance in the industry, the complexity of your contribution, the PR number and the quality code.
+- **Notes**: Check [Stackbuilders hacktoberfest blog](https://www.stackbuilders.com/news/join-us-for-our-first-hacktoberfest) for more information. Join [Stackbuilders Discord](https://discord.com/invite/S4QzFe8) to ask your doubts and talk about the event or your progress.
 
 #### **Switchblade**
 
 - **Swag**: Stickers
 - **Requirements**: 3+ valid submitted PR's.
-- **How to sign up**: Message a core developer on the [community discord](https://community.switchblade.xyz/){:target="_blank"} after submitting the Pull Requests.
-- **Issues**: [#hacktoberfest](https://github.com/SwitchbladeBot/switchblade/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ahacktoberfest){:target="_blank"}
-- **Notes**: Check [this page](https://github.com/SwitchbladeBot/switchblade/issues/1203){:target="_blank"} for more information on how to claim the swag.
+- **How to sign up**: Message a core developer on the [community discord](https://community.switchblade.xyz/) after submitting the Pull Requests.
+- **Issues**: [#hacktoberfest](https://github.com/SwitchbladeBot/switchblade/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ahacktoberfest)
+- **Notes**: Check [this page](https://github.com/SwitchbladeBot/switchblade/issues/1203) for more information on how to claim the swag.
 
 ### T
 
 #### **Tripal**
 
 - **Swag**: T-shirt and sticker
-- **Requirements**: Make 4 or more valid PRs to one of two repositories: [Tripal core](https://github.com/tripal/tripal) or [t4d8](https://github.com/tripal/t4d8). PRs must be linked to a related issue page (you can create the issue!){:target="_blank"} and follow Drupal coding standards.
-- **How to sign up**: Make 4 valid contributions at any of the two repos and fill this [form](https://docs.google.com/forms/d/e/1FAIpQLSdULq2FunATZrHTvfkk6GbYfPDN2FAJ3Jxv0pt4PDXNByigHw/viewform){:target="_blank"} to get your swag.
-- **Notes**: Check out [Tripal Hacktoberfest 2020 blog post](https://tripal.info/news/tripal-hacktoberfest-2020) for more information. Join [Tripal slack](https://tripal-project.slack.com/){:target="_blank"} and ask your doubts in dedicated #codefest channel.
+- **Requirements**: Make 4 or more valid PRs to one of two repositories: [Tripal core](https://github.com/tripal/tripal) or [t4d8](https://github.com/tripal/t4d8). PRs must be linked to a related issue page (you can create the issue!) and follow Drupal coding standards.
+- **How to sign up**: Make 4 valid contributions at any of the two repos and fill this [form](https://docs.google.com/forms/d/e/1FAIpQLSdULq2FunATZrHTvfkk6GbYfPDN2FAJ3Jxv0pt4PDXNByigHw/viewform) to get your swag.
+- **Notes**: Check out [Tripal Hacktoberfest 2020 blog post](https://tripal.info/news/tripal-hacktoberfest-2020) for more information. Join [Tripal slack](https://tripal-project.slack.com/) and ask your doubts in dedicated #codefest channel.
 
 ### U
 
@@ -354,19 +354,19 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: Udemy Course, T-shirt
 - **Requirements**:
-  - Star [Uno Platform repo](https://github.com/unoplatform/uno/stargazers)(Optional){:target="_blank"}
+  - Star [Uno Platform repo](https://github.com/unoplatform/uno/stargazers)(Optional)
   - 1+ Merged PR: Udemy Course – Introduction to Uno Platform
-- **How to sign up**: Make a valid contribution [#hacktoberfest issues](https://github.com/unoplatform/uno/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-desc+label%3Ahacktoberfest) in Uno repo and fill this [form](https://www.surveymonkey.com/r/FNDG269){:target="_blank"}.
-- **Notes**: You need to enter a draw to receive one of 30 Uno Platform T-shirts. Check out [Uno Hacktoberfest blog post](https://platform.uno/blog/hacktoberfest-2020-contribute-to-uno-to-win-online-courses-and-t-shirts/) for more information and read [contributing guide](https://platform.uno/docs/articles/uno-development/contributing-intro.html){:target="_blank"} for better understanding.
+- **How to sign up**: Make a valid contribution [#hacktoberfest issues](https://github.com/unoplatform/uno/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-desc+label%3Ahacktoberfest) in Uno repo and fill this [form](https://www.surveymonkey.com/r/FNDG269).
+- **Notes**: You need to enter a draw to receive one of 30 Uno Platform T-shirts. Check out [Uno Hacktoberfest blog post](https://platform.uno/blog/hacktoberfest-2020-contribute-to-uno-to-win-online-courses-and-t-shirts/) for more information and read [contributing guide](https://platform.uno/docs/articles/uno-development/contributing-intro.html) for better understanding.
 
 ### V
 
 #### **Vonage/Nexmo**
 
 - **Swag**: $5 Open Collective Gift Card or Bamboo Vonage Socks
-- **Requirements**: Make one valid contribution to one of the [Vonage](https://github.com/Vonage), [Nexmo](https://github.com/nexmo), [Nexmo Community](https://github.com/nexmo-community), [OpenToc](https://github.com/opentok), or [OpenToc Community](https://github.com/opentok-community){:target="_blank"} repos.
-- **How to sign up**: Make a valid contribution at any of the above repos and fill this [form](https://airtable.com/shrMXMw6Nwd3Rnjn4){:target="_blank"}.
-- **Notes**: Check out [Vonage Hacktoberfest](https://developer.nexmo.com/hacktoberfest){:target="_blank"} for more information and updates.
+- **Requirements**: Make one valid contribution to one of the [Vonage](https://github.com/Vonage), [Nexmo](https://github.com/nexmo), [Nexmo Community](https://github.com/nexmo-community), [OpenToc](https://github.com/opentok), or [OpenToc Community](https://github.com/opentok-community) repos.
+- **How to sign up**: Make a valid contribution at any of the above repos and fill this [form](https://airtable.com/shrMXMw6Nwd3Rnjn4).
+- **Notes**: Check out [Vonage Hacktoberfest](https://developer.nexmo.com/hacktoberfest) for more information and updates.
 
 ### W
 
@@ -375,10 +375,10 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Swag**: Special Webiny Swag Pack and T-Shirt
 - **Requirements**:
   - Make four successful pull requests in October 2020 to any open source project
-  - Make 2 successful pull requests to [Webiny](https://github.com/webiny/webiny-js){:target="_blank"}
-- **How to sign up**: Join the [community](https://webiny.com/slack), and register [here](https://www.webiny.com/swag){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/search?q=org%3Awebiny+label%3Ahacktoberfest) or [project-board](https://github.com/webiny/webiny-js/projects/12){:target="_blank"}
-- **Notes**: Check out the [contributing guidelines](https://github.com/webiny/webiny-js/blob/master/docs/CONTRIBUTING.md), read the [blog post](https://dev.to/webiny/webiny-hacktoberfest-2020-49h4), and join the [slack channel](https://webiny.com/slack){:target="_blank"} for help and discussions.
+  - Make 2 successful pull requests to [Webiny](https://github.com/webiny/webiny-js)
+- **How to sign up**: Join the [community](https://webiny.com/slack), and register [here](https://www.webiny.com/swag)
+- **Issues**: [#hacktoberfest](https://github.com/search?q=org%3Awebiny+label%3Ahacktoberfest) or [project-board](https://github.com/webiny/webiny-js/projects/12)
+- **Notes**: Check out the [contributing guidelines](https://github.com/webiny/webiny-js/blob/master/docs/CONTRIBUTING.md), read the [blog post](https://dev.to/webiny/webiny-hacktoberfest-2020-49h4), and join the [slack channel](https://webiny.com/slack) for help and discussions.
 
 ### Z
 
@@ -386,11 +386,11 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Swag**: T-Shirt
 - **Requirements**:
-  - Contribute with two or more Pull Requests on the [Zup IT Repositories](https://github.com/ZupIT){:target="_blank"} in October 2020.
+  - Contribute with two or more Pull Requests on the [Zup IT Repositories](https://github.com/ZupIT) in October 2020.
   - Ensure that at least two Pull Request are accepted.
-- **How to sign up**: Make two PRs to any of [Zup IT Repositories](https://github.com/ZupIT){:target="_blank"} and they'll send you a link.
-- **Issues**: [Zup IT #hacktoberfest](https://github.com/search?q=org%3AZupIT+label%3Ahacktoberfest+state%3Aopen+type%3Aissue+user%3AZupIT){:target="_blank"} or any issue you would like to help with.
-- **Notes**: Only the first 200 people residing in Brazil will receive the T-Shirt. Read the [ZupIT hacktoberfest page](https://insights.zup.com.br/hacktoberfest){:target="_blank"} for more information and help.
+- **How to sign up**: Make two PRs to any of [Zup IT Repositories](https://github.com/ZupIT) and they'll send you a link.
+- **Issues**: [Zup IT #hacktoberfest](https://github.com/search?q=org%3AZupIT+label%3Ahacktoberfest+state%3Aopen+type%3Aissue+user%3AZupIT) or any issue you would like to help with.
+- **Notes**: Only the first 200 people residing in Brazil will receive the T-Shirt. Read the [ZupIT hacktoberfest page](https://insights.zup.com.br/hacktoberfest) for more information and help.
 
 ---
 
@@ -402,14 +402,14 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Requirements**: First valid PR.
 - **Swag**: IBM Open Source Contributor badge.
-- **How to sign up**: Submit your PR links before October 31, 2020 on [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (you'll need to be in IBM VPN){:target="_blank"}.
+- **How to sign up**: Submit your PR links before October 31, 2020 on [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (you'll need to be in IBM VPN).
 
 #### **Vonage/Nexmo** ($5 Open Collective Gift Card or Bamboo Vonage Socks)
 
-- **Requirements**: Make one valid contribution to one of the [Vonage](https://github.com/Vonage), [Nexmo](https://github.com/nexmo), [Nexmo Community](https://github.com/nexmo-community), [OpenToc](https://github.com/opentok), or [OpenToc Community](https://github.com/opentok-community){:target="_blank"} repos.
+- **Requirements**: Make one valid contribution to one of the [Vonage](https://github.com/Vonage), [Nexmo](https://github.com/nexmo), [Nexmo Community](https://github.com/nexmo-community), [OpenToc](https://github.com/opentok), or [OpenToc Community](https://github.com/opentok-community) repos.
 - **Swag**: $5 Open Collective Gift Card or a pair of Bamboo Vonage Socks
-- **How to sign up**: Make a valid contribution at any of the above repos and fill this [form](https://airtable.com/shrMXMw6Nwd3Rnjn4){:target="_blank"}.
-- **Notes**: Check out [Vonage Hacktoberfest](https://developer.nexmo.com/hacktoberfest){:target="_blank"} for more information and updates.
+- **How to sign up**: Make a valid contribution at any of the above repos and fill this [form](https://airtable.com/shrMXMw6Nwd3Rnjn4).
+- **Notes**: Check out [Vonage Hacktoberfest](https://developer.nexmo.com/hacktoberfest) for more information and updates.
 
 ### 1 Merged PR
 
@@ -418,39 +418,39 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - 1 or more merged PR: stickers
 - **Swag**: Stickers
-- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md){:target="_blank"} before making pull requests.
+- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub)
+- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest) or any issue you like to help with.
+- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md) before making pull requests.
 
 #### **Appsmith** (Stickers)
 
-- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith){:target="_blank"}
+- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith)
   - 1+ merged PR: Stickers
 - **Swag**: Stickers
-- **How to sign up**: Raise a PR and join them on discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp){:target="_blank"} for more information and help.
+- **How to sign up**: Raise a PR and join them on discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863)
+- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest) or any issue you like to help with.
+- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp) for more information and help.
 
 #### **Appwrite** (Stickers, Magnets, and Buttons)
 
-- **Requirements**: Create one or more merged pull requests on any of [Appwrite repos](https://github.com/appwrite){:target="_blank"}.
+- **Requirements**: Create one or more merged pull requests on any of [Appwrite repos](https://github.com/appwrite).
 - **Swag**: Stickers, magnets, and buttons
-- **How to sign up**: Make a PR on any of [Appwrite GitHub Repos](https://github.com/appwrite){:target="_blank"} and they'll send you a link.
-- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3Aappwrite+label%3Ahacktoberfest+type:issue&state=open&type=Issues){:target="_blank"} or any issue you like to help with.
-- **Notes**: Follow [Appwrite blog](https://medium.com/appwrite-io) and [Discord community](https://appwrite.io/discord){:target="_blank"} for more information and help.
+- **How to sign up**: Make a PR on any of [Appwrite GitHub Repos](https://github.com/appwrite) and they'll send you a link.
+- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3Aappwrite+label%3Ahacktoberfest+type:issue&state=open&type=Issues) or any issue you like to help with.
+- **Notes**: Follow [Appwrite blog](https://medium.com/appwrite-io) and [Discord community](https://appwrite.io/discord) for more information and help.
 
 #### **AquaSecurity** (Stickers, face mask)
 
 - **Requirements**:
   - 1+ merged PR: stickers or face mask
 - **Swag**: stickers, face mask
-- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u){:target="_blank"}. The projects are:
-  - [kube-bench](https://github.com/aquasecurity/kube-bench){:target="_blank"}
-  - [Trivy](https://github.com/aquasecurity/Trivy){:target="_blank"}
-  - [Tracee](https://github.com/aquasecurity/tracee){:target="_blank"}
-  - [Starboard](https://github.com/aquasecurity/Starboard){:target="_blank"}
-  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter){:target="_blank"}
-- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest){:target="_blank"} for more information and contribution guide.
+- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u). The projects are:
+  - [kube-bench](https://github.com/aquasecurity/kube-bench)
+  - [Trivy](https://github.com/aquasecurity/Trivy)
+  - [Tracee](https://github.com/aquasecurity/tracee)
+  - [Starboard](https://github.com/aquasecurity/Starboard)
+  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter)
+- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest) for more information and contribution guide.
 
 #### **CircleCI** (Stickers and Magic Pin)
 
@@ -460,35 +460,35 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Swag**: T-shirt, stickers and Limited Edition Magic Orb Pin
 - **How to sign up**:
   - Challenge 1: Complete a merged or accepted PR to include orb usage on an existing CircleCI config
-  - Challenge 2: Develop and publish an orb using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit){:target="_blank"}. Make sure your orb offers value to other developers!
-  - After you are done with any one of the two challenges use [this](https://circleci-community.typeform.com/to/mErGL0nv){:target="_blank"} form to enter you PRs.
-- **Notes**: Check out the official website of CircleCI [here](https://hacktoberfest.circleci.com/){:target="_blank"}. PRs must either be merged or tagged with the "Orbtoberfest" label to count.
+  - Challenge 2: Develop and publish an orb using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit). Make sure your orb offers value to other developers!
+  - After you are done with any one of the two challenges use [this](https://circleci-community.typeform.com/to/mErGL0nv) form to enter you PRs.
+- **Notes**: Check out the official website of CircleCI [here](https://hacktoberfest.circleci.com/). PRs must either be merged or tagged with the "Orbtoberfest" label to count.
 
 #### **Commerce.js** (Swag bundle)
 
 - **Requirements**: 1 merged PR
 - **Swag**: Commerce.js swag bundle
-- **How to sign up**: There are many issues with the [#hacktoberfest](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+) tag or view more ways to contribute and fill out the form [here](https://commercejs.com/docs/hacktoberfest/){:target="_blank"}.
-- **Issues**: [Commerce.js](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+){:target="_blank"}
-- **Notes**: For more details visit their [contributing guidelines](https://commercejs.com/docs/community/contribute) and dedicated [Hacktoberfest page](https://commercejs.com/docs/hacktoberfest/){:target="_blank"} to get involved.
+- **How to sign up**: There are many issues with the [#hacktoberfest](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+) tag or view more ways to contribute and fill out the form [here](https://commercejs.com/docs/hacktoberfest/).
+- **Issues**: [Commerce.js](https://github.com/issues?q=is%3Aopen+is%3Aissue+label%3Ahacktoberfest+archived%3Afalse+user%3Achec+)
+- **Notes**: For more details visit their [contributing guidelines](https://commercejs.com/docs/community/contribute) and dedicated [Hacktoberfest page](https://commercejs.com/docs/hacktoberfest/) to get involved.
 
 #### **Datenanfragen.de e. V.** (Stickers, T-Shirt option)
 
 - **Requirements**:
-  - Eligible repositories include most repos of the Datenanfragen organization. They are listed [here](https://www.datarequests.org/blog/hacktoberfest-2020/#repos){:target="_blank"}
+  - Eligible repositories include most repos of the Datenanfragen organization. They are listed [here](https://www.datarequests.org/blog/hacktoberfest-2020/#repos)
   - 1 merged pull request to get at least 3 stickers (limited to 100 sets)
   - T-shirts are given to 10 people drawn from the contributors
 - **Swag**: At least 3 stickers and maybe a T-shirt
-- **How to sign up**: Submit to the repositories either via PR on GitHub or via patch file by email and register using the [webform](https://www.datarequests.org/blog/hacktoberfest-2020){:target="_blank"} before November 4, 2020.
-- **Issues**: [datenanfragen](https://github.com/search?&q=user%3Adatenanfragen+type:issue&state=open&type=Issues){:target="_blank"}
-- **Notes**: Take a look at [this blog post](https://www.datarequests.org/blog/hacktoberfest-2020/){:target="_blank"} for more info.
+- **How to sign up**: Submit to the repositories either via PR on GitHub or via patch file by email and register using the [webform](https://www.datarequests.org/blog/hacktoberfest-2020) before November 4, 2020.
+- **Issues**: [datenanfragen](https://github.com/search?&q=user%3Adatenanfragen+type:issue&state=open&type=Issues)
+- **Notes**: Take a look at [this blog post](https://www.datarequests.org/blog/hacktoberfest-2020/) for more info.
 
 #### **Earthly** (Stickers)
 
 - **Swag**: Stickers (limit 40)
-- **Requirements**: Contribute code to the [Earthly](https://github.com/earthly/earthly){:target="_blank"} open source build tool or contribute an Earthfile build to any public repo.
-- **How to sign up**: [Grab an issue](https://github.com/earthly/earthly/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest) and after completion they will reach out to you to get your mailing address or reach out to adam@earthly.dev via email to claim your sticker.  If you aren't sure what to work on, [Let's chat](https://gitter.im/earthly-room/community){:target="_blank"}
-- **Notes**: If you have any questions or need help with anything, join the [Community Gitter Channel]( https://gitter.im/earthly-room/community). They will gladly help you. See the [Blog post](https://blog.earthly.dev/hacktoberfest-2020/){:target="_blank"} for more details. Reach out to adam@earthly.dev via email to claim your sticker.
+- **Requirements**: Contribute code to the [Earthly](https://github.com/earthly/earthly) open source build tool or contribute an Earthfile build to any public repo.
+- **How to sign up**: [Grab an issue](https://github.com/earthly/earthly/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest) and after completion they will reach out to you to get your mailing address or reach out to adam@earthly.dev via email to claim your sticker.  If you aren't sure what to work on, [Let's chat](https://gitter.im/earthly-room/community)
+- **Notes**: If you have any questions or need help with anything, join the [Community Gitter Channel]( https://gitter.im/earthly-room/community). They will gladly help you. See the [Blog post](https://blog.earthly.dev/hacktoberfest-2020/) for more details. Reach out to adam@earthly.dev via email to claim your sticker.
 
 #### **Globo** (T-shirt, Brazil only)
 
@@ -496,8 +496,8 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - Contribute to two pull requests in any Globo Open Source project during the month of October.
   - Ensure that at least one pull request is merged.
 - **Swag**: T-shirt
-- **How to sign up**: Make two PRs to any of Globo's open-source projects – [Globo Home](https://github.com/globocom){:target="_blank"}
-- **Notes**: Only the first 100 people, residing in Brazil will receive the t-shirt. Read their [Hacktoberfest page here](https://opensource.globo.com/hacktoberfest/){:target="_blank"}
+- **How to sign up**: Make two PRs to any of Globo's open-source projects – [Globo Home](https://github.com/globocom)
+- **Notes**: Only the first 100 people, residing in Brazil will receive the t-shirt. Read their [Hacktoberfest page here](https://opensource.globo.com/hacktoberfest/)
 
 #### **Hasura** (Stickers, T-shirt)
 
@@ -506,93 +506,93 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - 1+ merged PR with a small fix, such as typo: Stickers
 - **Swag**: T-shirt, stickers
 - **How to sign up**: Submit a PR to any of the following repositories:
-  - [GraphQL Engine](https://github.com/hasura/graphql-engine){:target="_blank"}
-  - [Learn GraphQL](https://github.com/hasura/learn-graphql){:target="_blank"}
+  - [GraphQL Engine](https://github.com/hasura/graphql-engine)
+  - [Learn GraphQL](https://github.com/hasura/learn-graphql)
 - **Notes**:
   - If you have any questions or need help with anything, available options:
-    - Open a [Github Discussion](https://github.com/hasura/graphql-engine/discussions){:target="_blank"} if the question is not already posted.
-    - #contrib channel on [Discord server](http://hasura.io/discord){:target="_blank"}
-    - [Tweet](https://twitter.com/HasuraHQ){:target="_blank"}
-  - Guidelines available at: [Guidelines](https://hasura.io/blog/hasura-joins-hacktoberfest-3rd-year-in-a-row){:target="_blank"}
+    - Open a [Github Discussion](https://github.com/hasura/graphql-engine/discussions) if the question is not already posted.
+    - #contrib channel on [Discord server](http://hasura.io/discord)
+    - [Tweet](https://twitter.com/HasuraHQ)
+  - Guidelines available at: [Guidelines](https://hasura.io/blog/hasura-joins-hacktoberfest-3rd-year-in-a-row)
 
 #### **InfraCloud** (Stickers, T-shirt)
 
-- **Requirements**: one or more merged PRs on [Fission](https://github.com/fission/fission) or [BotKube](https://github.com/infracloudio/botkube){:target="_blank"} or both.
+- **Requirements**: one or more merged PRs on [Fission](https://github.com/fission/fission) or [BotKube](https://github.com/infracloudio/botkube) or both.
 - **Swag**: T-shirt, stickers
-- **How to sign up**: Make a PR or more on InfraCloud's open-source projects – [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube). To deliver the swags, we will reach out to you once PR(s){:target="_blank"} gets merged.
-- **Notes**: Only the first 50 people will receive the swags. A person with maximum merged PRs will also get a Kindle. Check out [InfraCloud official page](https://www.infracloud.io/infracloud-joins-hacktoberfest-2020/) for more info and join [Fission’s Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE) and [BotKube’s Slack](http://join.botkube.io/){:target="_blank"}.
+- **How to sign up**: Make a PR or more on InfraCloud's open-source projects – [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube). To deliver the swags, we will reach out to you once PR(s) gets merged.
+- **Notes**: Only the first 50 people will receive the swags. A person with maximum merged PRs will also get a Kindle. Check out [InfraCloud official page](https://www.infracloud.io/infracloud-joins-hacktoberfest-2020/) for more info and join [Fission’s Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE) and [BotKube’s Slack](http://join.botkube.io/).
 
 #### **lakeFS** (collection of stickers)
 
 - **Requirements**: One merged pull request for a collection of stickers
 - **Swag**: Stickers
-- **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS){:target="_blank"} and they'll send you a link.
-- **Notes**: Check out the [contributing guide](https://docs.lakefs.io/contributing) and join the [slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw){:target="_blank"} for help and discussions.
+- **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS) and they'll send you a link.
+- **Notes**: Check out the [contributing guide](https://docs.lakefs.io/contributing) and join the [slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw) for help and discussions.
 
 #### **LoginRadius** (T-shirt, Stickers)
 
-- **Requirements**: Make one successful pull request in October 2020 to any open source [LoginRadius repository](https://github.com/LoginRadius){:target="_blank"} and earn a T-shirt and Swags!
+- **Requirements**: Make one successful pull request in October 2020 to any open source [LoginRadius repository](https://github.com/LoginRadius) and earn a T-shirt and Swags!
 - **Swag**: T-Shirt, stickers
-- **How to sign up**: Fill the [form](https://forms.gle/aUYJXoVJVivPgGuM8) and make a successful PR on any of [LoginRadius repository](https://github.com/LoginRadius){:target="_blank"}.
-- **Notes**: Keep in touch from the [LoginRadius Engineering Blog](https://www.loginradius.com/engineering/page/hacktoberfest2020){:target="_blank"} site for more updates.
+- **How to sign up**: Fill the [form](https://forms.gle/aUYJXoVJVivPgGuM8) and make a successful PR on any of [LoginRadius repository](https://github.com/LoginRadius).
+- **Notes**: Keep in touch from the [LoginRadius Engineering Blog](https://www.loginradius.com/engineering/page/hacktoberfest2020) site for more updates.
 
 #### **Mattermost** (Mug)
 
 - **Requirements**: One or more merged PR(s)
 - **Swag**: Mug
-- **How to sign up**: Create one or more PR(s) on [Mattermost featured projects](https://mattermost.com/hacktoberfest/). If you contribute to Mattermost and it’s your first time contributing, you’ll also [earn some swag](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143/6){:target="_blank"} from them!
-- **Notes**: Check out the [Mattermost Hacktoberfest blog](https://mattermost.com/blog/hacktoberfest-2020/) for more information and read the [contribution guidelines](https://developers.mattermost.com/contribute/getting-started/){:target="_blank"} about how to contribute.
+- **How to sign up**: Create one or more PR(s) on [Mattermost featured projects](https://mattermost.com/hacktoberfest/). If you contribute to Mattermost and it’s your first time contributing, you’ll also [earn some swag](https://forum.mattermost.org/t/limited-edition-mattermost-mugs/143/6) from them!
+- **Notes**: Check out the [Mattermost Hacktoberfest blog](https://mattermost.com/blog/hacktoberfest-2020/) for more information and read the [contribution guidelines](https://developers.mattermost.com/contribute/getting-started/) about how to contribute.
 
 #### **MayaData** (T-shirt, stickers)
 
 - **Requirements**:
   - 1+ merged PR: T-shirt and sticker
 - **Swag**: T-shirt, stickers
-- **How to sign up**: Fill form from the link you will receive once your PR is merged. PR can be from [OpenEBS](https://github.com/openebs/openebs) or [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest){:target="_blank"}.
-- **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest){:target="_blank"}
-- **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata){:target="_blank"}.
+- **How to sign up**: Fill form from the link you will receive once your PR is merged. PR can be from [OpenEBS](https://github.com/openebs/openebs) or [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest).
+- **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest)
+- **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata).
 
 #### **Meedan** (T-shirt, stickers, mask)
 
-- **Requirements**: Get at least one pull request merged on any of the services that support the [Check platform](https://github.com/meedan/check){:target="_blank"}
+- **Requirements**: Get at least one pull request merged on any of the services that support the [Check platform](https://github.com/meedan/check)
 - **Swag**: T-shirt, stickers, mask
 - **How to sign up**: Make one PR or more on any Check's open source services. After the PR(s) gets merged we will reach out to you to get shipping information.
-- **Issues**: [Check issues](https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest){:target="_blank"}
-- **Notes**: Check out [Meedan's Hacktoberfest page](https://meedan.com/hacktoberfest){:target="_blank"} for more information.
+- **Issues**: [Check issues](https://github.com/meedan/check/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest)
+- **Notes**: Check out [Meedan's Hacktoberfest page](https://meedan.com/hacktoberfest) for more information.
 
 #### **Sensenet** (Socks and discount code)
 
 - **Requirements**:
   - 1+ merged PR
-- **Swag**: Sensenet special edition socks (limit 60), 10% discount code for their [business plan](https://sensenet.com/pricing){:target="_blank"}.
-- **How to sign up**: Complete the entry challenge by [creating a sensenet content repository](https://profile.sensenet.com/?redirectToLogin) and starring [sensenet's GitHub repository](https://github.com/SenseNet/sensenet){:target="_blank"}.
-- **Notes**: Check out [sensenet's Hacktoberfest page](https://hacktoberfest.sensenet.com/). Pull requests only count if they correspond to an issue found on the [dedicated board](https://github.com/orgs/SenseNet/projects/7){:target="_blank"}.
+- **Swag**: Sensenet special edition socks (limit 60), 10% discount code for their [business plan](https://sensenet.com/pricing).
+- **How to sign up**: Complete the entry challenge by [creating a sensenet content repository](https://profile.sensenet.com/?redirectToLogin) and starring [sensenet's GitHub repository](https://github.com/SenseNet/sensenet).
+- **Notes**: Check out [sensenet's Hacktoberfest page](https://hacktoberfest.sensenet.com/). Pull requests only count if they correspond to an issue found on the [dedicated board](https://github.com/orgs/SenseNet/projects/7).
 
 #### **Specflow** (Stickers)
 
 - **Requirements**: 1+ merged PR
 - **Swag**: Stickers
-- **How to sign up**: 1+ Merged PR to any [Specflow repo](https://github.com/SpecFlowOSS/SpecFlow/) and then [fill up this form](https://specflow.org/contributer-package/){:target="_blank"} to get swag.
-- **Issues**: New to Open source? Look for issues [#first-timers-only](https://github.com/SpecFlowOSS/SpecFlow/labels/first-timers-only) , [Up-for-grabs](https://github.com/SpecFlowOSS/SpecFlow/labels/up-for-grabs){:target="_blank"}.
-- **Notes**: Check out [Specflow Hacktoberfest 2020 blog](https://specflow.org/blog/hacktoberfest-2020-starts-soon/3) for more information and read [the contributing guide](https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md){:target="_blank"} on how to contribute.
+- **How to sign up**: 1+ Merged PR to any [Specflow repo](https://github.com/SpecFlowOSS/SpecFlow/) and then [fill up this form](https://specflow.org/contributer-package/) to get swag.
+- **Issues**: New to Open source? Look for issues [#first-timers-only](https://github.com/SpecFlowOSS/SpecFlow/labels/first-timers-only) , [Up-for-grabs](https://github.com/SpecFlowOSS/SpecFlow/labels/up-for-grabs).
+- **Notes**: Check out [Specflow Hacktoberfest 2020 blog](https://specflow.org/blog/hacktoberfest-2020-starts-soon/3) for more information and read [the contributing guide](https://github.com/SpecFlowOSS/SpecFlow/blob/master/CONTRIBUTING.md) on how to contribute.
 
 #### **Uno** (Udemy Course, Uno Platform)
 
 - **Requirements**:
-  - Star [Uno Platform repo](https://github.com/unoplatform/uno/stargazers)(Optional){:target="_blank"}
+  - Star [Uno Platform repo](https://github.com/unoplatform/uno/stargazers)(Optional)
   - 1+ Merged PR: Udemy Course – Introduction to Uno Platform
 - **Swag**: Udemy Course, T-shirt
-- **How to sign up**: Make a valid contribution [#hacktoberfest issues](https://github.com/unoplatform/uno/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-desc+label%3Ahacktoberfest) in Uno repo and fill this [form](https://www.surveymonkey.com/r/FNDG269){:target="_blank"}.
-- **Notes**: You need to enter a draw to receive one of 30 Uno Platform T-shirts. Check out [Uno Hacktoberfest blog post](https://platform.uno/blog/hacktoberfest-2020-contribute-to-uno-to-win-online-courses-and-t-shirts/) for more information and read [contributing guide](https://platform.uno/docs/articles/uno-development/contributing-intro.html){:target="_blank"} for better understanding.
+- **How to sign up**: Make a valid contribution [#hacktoberfest issues](https://github.com/unoplatform/uno/issues?q=is%3Aopen+is%3Aissue+sort%3Aupdated-desc+label%3Ahacktoberfest) in Uno repo and fill this [form](https://www.surveymonkey.com/r/FNDG269).
+- **Notes**: You need to enter a draw to receive one of 30 Uno Platform T-shirts. Check out [Uno Hacktoberfest blog post](https://platform.uno/blog/hacktoberfest-2020-contribute-to-uno-to-win-online-courses-and-t-shirts/) for more information and read [contributing guide](https://platform.uno/docs/articles/uno-development/contributing-intro.html) for better understanding.
 
 ### 2 or more PRs
 
 ### The Original - **DigitalOcean, Intel, and DEV** (T-shirt, stickers)
 
-- **Requirements**: 4 pull requests in any eligible [repository](https://github.com/topics/hacktoberfest){:target="_blank"}
+- **Requirements**: 4 pull requests in any eligible [repository](https://github.com/topics/hacktoberfest)
 - **Swag**: T-shirt, stickers
-- **How to sign up**: [Hacktoberfest Website](https://hacktoberfest.digitalocean.com){:target="_blank"}
-- **Notes**: Please see [updates for repo eligibiliy and a statent from Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update){:target="_blank"} For your PR to count it must be:
+- **How to sign up**: [Hacktoberfest Website](https://hacktoberfest.digitalocean.com)
+- **Notes**: Please see [updates for repo eligibiliy and a statent from Hacktoberfest](https://hacktoberfest.digitalocean.com/hacktoberfest-update) For your PR to count it must be:
   - Submitted in a repo labeled ```hacktoberfest``` AND
   - Merged, OR
   - Labelled ```hacktoberfest-accepted```  by a maintainer, OR
@@ -602,15 +602,15 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 
 - **Requirements**: 4+ submitted PR's
 - **Swag**: IBM Developer Swag
-- **How to sign up**: Submit your PR links before October 31, 2020 on [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (you'll need to be in IBM VPN){:target="_blank"}.
-- **Notes**: Only first 250 IBMers are eligible for the developer swag. Refer to [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (IBM VPN needed){:target="_blank"} for complete guidelines/requirements.
+- **How to sign up**: Submit your PR links before October 31, 2020 on [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (you'll need to be in IBM VPN).
+- **Notes**: Only first 250 IBMers are eligible for the developer swag. Refer to [IBM Hacktoberfest internal page](https://w3.ibm.com/developer/hacktoberfest/) (IBM VPN needed) for complete guidelines/requirements.
 
 #### **JetBrains** (Access to all professional tools for 3 months, 20% off after that)
 
 - **Requirements**: 4+ submitted PR's
 - **Swag**: Access to all professional developer tools for 3 months, plus 20% off an annual subscription.
-- **How to sign up**: Please fill out this [Get your Hacktoberfest participant perks from JetBrains](https://www.jetbrains.com/lp/hacktoberfest-2020/#get-the-tools){:target="_blank"} form and then make four quality pull requests to public GitHub repositories. Once you register by filling out the form, you will get a 3 month subscription to their professional tools to use after Hacktoberfest!
-- **Notes**: You can contact them by sending email to marketing@jetbrains.com and by joining [Discord](https://discord.com/invite/hacktoberfest). You can read more about them [here](https://www.jetbrains.com/lp/hacktoberfest-2020/){:target="_blank"}.
+- **How to sign up**: Please fill out this [Get your Hacktoberfest participant perks from JetBrains](https://www.jetbrains.com/lp/hacktoberfest-2020/#get-the-tools) form and then make four quality pull requests to public GitHub repositories. Once you register by filling out the form, you will get a 3 month subscription to their professional tools to use after Hacktoberfest!
+- **Notes**: You can contact them by sending email to marketing@jetbrains.com and by joining [Discord](https://discord.com/invite/hacktoberfest). You can read more about them [here](https://www.jetbrains.com/lp/hacktoberfest-2020/).
 
 ### 2 or more Merged PRs
 
@@ -619,39 +619,39 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - 3 or more merged PRs: T-shirt plus a choice of stickers or face mask
 - **Swag**: T-Shirt, stickers, face mask
-- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md){:target="_blank"} before making pull requests.
+- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub)
+- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest) or any issue you like to help with.
+- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md) before making pull requests.
 
 #### **Appsmith** (T-shirt and stickers)
 
-- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith){:target="_blank"}
+- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith)
   - 1+ merged PR: Stickers
   - 3+ merged PR: T-Shirt
 - **Swag**: T-Shirt, stickers
-- **How to sign up**: Raise a PR and join them  on discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp){:target="_blank"} for more information and help.
+- **How to sign up**: Raise a PR and join them  on discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863)
+- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest) or any issue you like to help with.
+- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp) for more information and help.
 
 #### **AquaSecurity** (T-shirt plus stickers or face mask)
 
 - **Requirements**:
   - 3+ merged PR:  T-shirt, stickers or face mask
 - **Swag**: T-Shirt, stickers, face mask
-- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u){:target="_blank"} The projects are:
-  - [kube-bench](https://github.com/aquasecurity/kube-bench){:target="_blank"}
-  - [Trivy](https://github.com/aquasecurity/Trivy){:target="_blank"}
-  - [Tracee](https://github.com/aquasecurity/tracee){:target="_blank"}
-  - [Starboard](https://github.com/aquasecurity/Starboard){:target="_blank"}
-  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter){:target="_blank"}
-- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest){:target="_blank"} for more information and contribution guide.
+- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u) The projects are:
+  - [kube-bench](https://github.com/aquasecurity/kube-bench)
+  - [Trivy](https://github.com/aquasecurity/Trivy)
+  - [Tracee](https://github.com/aquasecurity/tracee)
+  - [Starboard](https://github.com/aquasecurity/Starboard)
+  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter)
+- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest) for more information and contribution guide.
 
 #### **CAMUNDA** (T-shirt, stickers)
 
 - **Requirements**: 2 or more merged PRs
 - **Swag**: T-shirt, stickers
-- **How to sign up**: You have submit two PRs then let them know you’ve completed the challenge by filling out the form on their [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/) and they will send you an e-mail. The repos are: [Camunda BPM](https://github.com/camunda/), [bpmn.io](https://github.com/bpmn-io/), and [Zeebe-io](https://github.com/zeebe-io/){:target="_blank"}.
-- **Notes**: Check out Camunda's [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/){:target="_blank"} for more info & how to get the T-shirt.
+- **How to sign up**: You have submit two PRs then let them know you’ve completed the challenge by filling out the form on their [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/) and they will send you an e-mail. The repos are: [Camunda BPM](https://github.com/camunda/), [bpmn.io](https://github.com/bpmn-io/), and [Zeebe-io](https://github.com/zeebe-io/).
+- **Notes**: Check out Camunda's [official Hacktoberfest page](https://camunda.com/hacktoberfest2020/) for more info & how to get the T-shirt.
 
 #### **CircleCI** (T-shirt, stickers and Magic Pin)
 
@@ -661,26 +661,26 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Swag**: T-shirt, stickers and Limited Edition Magic Orb Pin
 - **How to sign up**:
   - Challenge 1: Complete a merged or accepted PR to include orb usage on an existing CircleCI config
-  - Challenge 2: Develop and publish an orb using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit){:target="_blank"}. Make sure your orb offers value to other developers!
-  - After you are done with any one of the two challenges use [this](https://circleci-community.typeform.com/to/mErGL0nv){:target="_blank"} form to enter you PRs.
-- **Notes**: Check out the official website of CircleCI [here](https://hacktoberfest.circleci.com/){:target="_blank"}. PRs must either be merged or tagged with the "Orbtoberfest" label to count.
+  - Challenge 2: Develop and publish an orb using the [Orb Development Kit](https://circleci.com/docs/2.0/orb-author/#orb-development-kit). Make sure your orb offers value to other developers!
+  - After you are done with any one of the two challenges use [this](https://circleci-community.typeform.com/to/mErGL0nv) form to enter you PRs.
+- **Notes**: Check out the official website of CircleCI [here](https://hacktoberfest.circleci.com/). PRs must either be merged or tagged with the "Orbtoberfest" label to count.
 
 #### **Indeed** (Swearshirt, Shipping US only)
 
 - **Requirements**: 2 or more merged pull requests
 - **Swag**: Sweatshirt
 - **How to sign up**: Eligible Indeed repos:
-  - [k8dash](https://github.com/indeedeng/k8dash), [starfish](https://github.com/indeedeng/starfish), [FasterXML/jackson](https://github.com/FasterXML/jackson){:target="_blank"},
- [deps.cloud](https://github.com/depscloud/depscloud), [Mariner](https://github.com/indeedeng/mariner){:target="_blank"}
-  - Create two or more merged PRs and then [fill this form](https://docs.google.com/forms/d/e/1FAIpQLSeUKDE1fdyG3jRBngj0dnAXIEKscO128rrXw3a1BcFwNQ6iHg/viewform){:target="_blank"} to get your swag.
-- **Notes**: Check this out [Indeed blog](https://engineering.indeedblog.com/indeed-hacktoberfest-2020/){:target="_blank"} for more information and help.
+  - [k8dash](https://github.com/indeedeng/k8dash), [starfish](https://github.com/indeedeng/starfish), [FasterXML/jackson](https://github.com/FasterXML/jackson),
+ [deps.cloud](https://github.com/depscloud/depscloud), [Mariner](https://github.com/indeedeng/mariner)
+  - Create two or more merged PRs and then [fill this form](https://docs.google.com/forms/d/e/1FAIpQLSeUKDE1fdyG3jRBngj0dnAXIEKscO128rrXw3a1BcFwNQ6iHg/viewform) to get your swag.
+- **Notes**: Check this out [Indeed blog](https://engineering.indeedblog.com/indeed-hacktoberfest-2020/) for more information and help.
 
 #### **lakeFS** (T-shirt)
 
 - **Requirements**: 2 or more merged pull requests
 - **Swag**: T-shirt, stickers
-- **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS){:target="_blank"} and they'll send you a link.
-- **Notes**: Check out the [contributing guide](https://docs.lakefs.io/contributing) and join the [Slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw){:target="_blank"} for help and discussions
+- **How to sign up**: Make a PR on the [lakeFS Repo](https://github.com/treeverse/lakeFS) and they'll send you a link.
+- **Notes**: Check out the [contributing guide](https://docs.lakefs.io/contributing) and join the [Slack channel](https://join.slack.com/t/lakefs/shared_invite/zt-g86mkroy-186GzaxR4xOar1i1Us0bzw) for help and discussions
 
 #### **Operation Code** (T-shirt, Stickers)
 
@@ -688,42 +688,42 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - Merge 2+ PRs in any one of the Operation Code repositories: Stickers
   - Resolve 3 issues in any one of the Operation Code repositories: T-shirt
 - **Swag**: Stickers and/or T-shirt
-- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform){:target="_blank"}.
-- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE){:target="_blank"} for more information about how to contribute.
+- **How to sign up**: Submit your details via [this form](https://docs.google.com/forms/d/e/1FAIpQLSedQDzs_8HXhOC1jU7Ww1HDzBXITMBbE7vk3S8qneShduRgyg/viewform).
+- **Notes**: Visit their [official post](https://github.com/OperationCode/START_HERE) for more information about how to contribute.
 
 #### **Switchblade** (Stickers)
 
 - **Requirements**: 3+ valid submitted PR's.
 - **Swag**: Stickers
-- **How to sign up**: Message a core developer on the [community discord](https://community.switchblade.xyz/){:target="_blank"} after submitting the Pull Requests.
-- **Issues**: [#hacktoberfest](https://github.com/SwitchbladeBot/switchblade/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ahacktoberfest){:target="_blank"}
-- **Notes**: Check [this page](https://github.com/SwitchbladeBot/switchblade/issues/1203){:target="_blank"} for more information on how to claim the swag.
+- **How to sign up**: Message a core developer on the [community discord](https://community.switchblade.xyz/) after submitting the Pull Requests.
+- **Issues**: [#hacktoberfest](https://github.com/SwitchbladeBot/switchblade/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Ahacktoberfest)
+- **Notes**: Check [this page](https://github.com/SwitchbladeBot/switchblade/issues/1203) for more information on how to claim the swag.
 
 #### **Tripal** (T-shirt, Sticker)
 
-- **Requirements**: Make 4 or more valid PRs to one of two repositories: [Tripal core](https://github.com/tripal/tripal) or [t4d8](https://github.com/tripal/t4d8). PRs must be linked to a related issue page (you can create the issue!){:target="_blank"} and follow Drupal coding standards.
+- **Requirements**: Make 4 or more valid PRs to one of two repositories: [Tripal core](https://github.com/tripal/tripal) or [t4d8](https://github.com/tripal/t4d8). PRs must be linked to a related issue page (you can create the issue!) and follow Drupal coding standards.
 - **Swag**: T-shirt and sticker
-- **How to sign up**: Make 4 valid contributions at any of the two repos and fill this [form](https://docs.google.com/forms/d/e/1FAIpQLSdULq2FunATZrHTvfkk6GbYfPDN2FAJ3Jxv0pt4PDXNByigHw/viewform){:target="_blank"} to get your swag.
-- **Notes**: Check out [Tripal Hacktoberfest 2020 blog post](https://tripal.info/news/tripal-hacktoberfest-2020) for more information. Join [Tripal slack](https://tripal-project.slack.com/){:target="_blank"} and ask your doubts in dedicated #codefest channel.
+- **How to sign up**: Make 4 valid contributions at any of the two repos and fill this [form](https://docs.google.com/forms/d/e/1FAIpQLSdULq2FunATZrHTvfkk6GbYfPDN2FAJ3Jxv0pt4PDXNByigHw/viewform) to get your swag.
+- **Notes**: Check out [Tripal Hacktoberfest 2020 blog post](https://tripal.info/news/tripal-hacktoberfest-2020) for more information. Join [Tripal slack](https://tripal-project.slack.com/) and ask your doubts in dedicated #codefest channel.
 
 #### **Webiny** (Special Webiny Swag Pack, T-Shirt)
 
 - **Requirements**:
   - Make four successful pull requests in October 2020 to any open source project, and
-  - Make 2 successful pull requests to [Webiny](https://github.com/webiny/webiny-js){:target="_blank"}
+  - Make 2 successful pull requests to [Webiny](https://github.com/webiny/webiny-js)
 - **Swag**: Special Webiny Swag Pack and T-Shirt
-- **How to sign up**: Join the [community](https://webiny.com/slack), and register [here](https://www.webiny.com/swag){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/search?q=org%3Awebiny+label%3Ahacktoberfest) or [project-board](https://github.com/webiny/webiny-js/projects/12){:target="_blank"}
-- **Notes**: Check out the [contributing guidelines](https://github.com/webiny/webiny-js/blob/master/docs/CONTRIBUTING.md), read the [blog post](https://dev.to/webiny/webiny-hacktoberfest-2020-49h4) and join the [slack channel](https://webiny.com/slack){:target="_blank"} for help and discussions.
+- **How to sign up**: Join the [community](https://webiny.com/slack), and register [here](https://www.webiny.com/swag)
+- **Issues**: [#hacktoberfest](https://github.com/search?q=org%3Awebiny+label%3Ahacktoberfest) or [project-board](https://github.com/webiny/webiny-js/projects/12)
+- **Notes**: Check out the [contributing guidelines](https://github.com/webiny/webiny-js/blob/master/docs/CONTRIBUTING.md), read the [blog post](https://dev.to/webiny/webiny-hacktoberfest-2020-49h4) and join the [slack channel](https://webiny.com/slack) for help and discussions.
 
 #### **Zup Innovation** (T-Shirt)
 
 - **Requirements**:
-  - Contribute with two or more Pull Requests on the [Zup IT Repositories](https://github.com/ZupIT){:target="_blank"} in October 2020.
+  - Contribute with two or more Pull Requests on the [Zup IT Repositories](https://github.com/ZupIT) in October 2020.
   - Ensure that at least two Pull Request are accepted.
-- **How to sign up**: Make two PRs to any of [Zup IT Repositories](https://github.com/ZupIT){:target="_blank"} and they'll send you a link.
-- **Issues**: [Zup IT #hacktoberfest](https://github.com/search?q=org%3AZupIT+label%3Ahacktoberfest+state%3Aopen+type%3Aissue+user%3AZupIT){:target="_blank"} or any issue you would like to help with.
-- **Notes**: Only the first 200 people residing in Brazil will receive the T-Shirt. Read the [ZupIT hacktoberfest page](https://insights.zup.com.br/hacktoberfest){:target="_blank"} for more information and help.
+- **How to sign up**: Make two PRs to any of [Zup IT Repositories](https://github.com/ZupIT) and they'll send you a link.
+- **Issues**: [Zup IT #hacktoberfest](https://github.com/search?q=org%3AZupIT+label%3Ahacktoberfest+state%3Aopen+type%3Aissue+user%3AZupIT) or any issue you would like to help with.
+- **Notes**: Only the first 200 people residing in Brazil will receive the T-Shirt. Read the [ZupIT hacktoberfest page](https://insights.zup.com.br/hacktoberfest) for more information and help.
 
 ### 5 or more Merged PRs
 
@@ -732,22 +732,22 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - 5 or more merged PRs: T-shirt, stickers, and a face mask
 - **Swag**: T-Shirt, stickers, face mask
-- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md){:target="_blank"} before making pull requests.
+- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub)
+- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest) or any issue you like to help with.
+- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md) before making pull requests.
 
 #### **AquaSecurity** (T-shirt, stickers and face mask)
 
 - **Requirements**:
   - 3+ merged PR:  T-shirt, stickers and face mask
 - **Swag**: T-Shirt, stickers, face mask
-- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u){:target="_blank"}. The projects are:
-  - [kube-bench](https://github.com/aquasecurity/kube-bench){:target="_blank"}
-  - [Trivy](https://github.com/aquasecurity/Trivy){:target="_blank"}
-  - [Tracee](https://github.com/aquasecurity/tracee){:target="_blank"}
-  - [Starboard](https://github.com/aquasecurity/Starboard){:target="_blank"}
-  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter){:target="_blank"}
-- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest){:target="_blank"} for more information and contribution guide.
+- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u). The projects are:
+  - [kube-bench](https://github.com/aquasecurity/kube-bench)
+  - [Trivy](https://github.com/aquasecurity/Trivy)
+  - [Tracee](https://github.com/aquasecurity/tracee)
+  - [Starboard](https://github.com/aquasecurity/Starboard)
+  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter)
+- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest) for more information and contribution guide.
 
 ### Top Contributors
 
@@ -756,81 +756,81 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
 - **Requirements**:
   - Make the most merged PRs to win SONY WH-CH710 noise-cancelling headphones
 - **Swag**: Sony noise-cancelling headphones
-- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md){:target="_blank"} before making pull requests.
+- **How to sign up**: Make PRs on the [Activeloop Hub Repo](https://github.com/activeloopai/Hub)
+- **Issues**: [#hacktoberfest](https://github.com/activeloopai/Hub/labels/hacktoberfest) or any issue you like to help with.
+- **Notes**: Visit the [activeloop.ai Hacktoberfest Page](https://www.activeloop.ai/hacktoberfest/?utm_source=hacktoberfestswag&utm_medium=web&utm_campaign=swaglist) and read the [contribution guidelines](https://github.com/activeloopai/Hub/blob/master/CONTRIBUTING.md) before making pull requests.
 
 #### **Appsmith** (T-shirt, stickers, and a WASD Keyboard)
 
-- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith){:target="_blank"}
+- **Requirements**: Create one or more merged pull requests on the [Appsmith Repo](https://github.com/appsmithorg/appsmith)
   - 1+ PR: Stickers
   - 3+ PR: T-Shirt
   - Top contributor Referral: WASD Keyboard.
 - **Swag**: T-Shirt, stickers, WASD Keyboard
-- **How to sign up**: Raise a PR and join them on Discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863){:target="_blank"}
-- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest){:target="_blank"} or any issue you like to help with.
-- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp){:target="_blank"} for more information and help.
+- **How to sign up**: Raise a PR and join them on Discord. [Appsmith Hacktoberfest](https://github.com/appsmithorg/appsmith/discussions/863)
+- **Issues**: [#hacktoberfest](https://github.com/appsmithorg/appsmith/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest) or any issue you like to help with.
+- **Notes**: Join the [Discord community](https://discord.com/invite/rBTTVJp) for more information and help.
 
 #### **Appwrite** (T-shirt, Stickers, Magnets, and Buttons)
 
-- **Requirements**: Be one of the top contributors with merged pull requests on any of [Appwrite repos](https://github.com/appwrite){:target="_blank"}.
+- **Requirements**: Be one of the top contributors with merged pull requests on any of [Appwrite repos](https://github.com/appwrite).
 - **Swag**: T-Shirt, Stickers, Magnets, and Buttons
-- **How to sign up**: Make a PR on any of [Appwrite GitHub Repos](https://github.com/appwrite){:target="_blank"} and they'll send you a link.
-- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3Aappwrite+label%3Ahacktoberfest+type:issue&state=open&type=Issues){:target="_blank"} or any issue you like to help with.
-- **Notes**: Follow [Appwrite blog](https://medium.com/appwrite-io) and [Discord community](https://appwrite.io/discord){:target="_blank"} for more information and help.
+- **How to sign up**: Make a PR on any of [Appwrite GitHub Repos](https://github.com/appwrite) and they'll send you a link.
+- **Issues**: [#hacktoberfest](https://github.com/search?&q=user%3Aappwrite+label%3Ahacktoberfest+type:issue&state=open&type=Issues) or any issue you like to help with.
+- **Notes**: Follow [Appwrite blog](https://medium.com/appwrite-io) and [Discord community](https://appwrite.io/discord) for more information and help.
 
 #### **AquaSecurity** (T-shirt, Stickers, face masks, Kubernetes Security Book)
 
 - **Requirements**:
-  - Top 3 Contributors: - [Kubernetes Security Book](https://www.oreilly.com/library/view/kubernetes-security/9781492039075/) signed by [Liz Rice](https://www.lizrice.com/){:target="_blank"}.
+  - Top 3 Contributors: - [Kubernetes Security Book](https://www.oreilly.com/library/view/kubernetes-security/9781492039075/) signed by [Liz Rice](https://www.lizrice.com/).
 - **Swag**: T-Shirt, stickers, face mask, book
-- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u){:target="_blank"}s The projects are:
-  - [kube-bench](https://github.com/aquasecurity/kube-bench){:target="_blank"}
-  - [Trivy](https://github.com/aquasecurity/Trivy){:target="_blank"}
-  - [Tracee](https://github.com/aquasecurity/tracee){:target="_blank"}
-  - [Starboard](https://github.com/aquasecurity/Starboard){:target="_blank"}
-  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter){:target="_blank"}
-- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest){:target="_blank"} for more information and contribution guide.
+- **How to sign up**: Create PRs to the following projects by Aqua Security and fill up the [form](https://forms.office.com/Pages/ResponsePage.aspx?id=80wDvGtWykGfJF3ElHSwXoMzxQ44cLZDuLrHx6o4yX1UNklOSjVNOVFCSUtMVkVKR1VEU1haQVpUOS4u)s The projects are:
+  - [kube-bench](https://github.com/aquasecurity/kube-bench)
+  - [Trivy](https://github.com/aquasecurity/Trivy)
+  - [Tracee](https://github.com/aquasecurity/tracee)
+  - [Starboard](https://github.com/aquasecurity/Starboard)
+  - [Kube-hunter](https://github.com/aquasecurity/kube-hunter)
+- **Notes**: Check out [AquaSecurity blog](https://blog.aquasec.com/hacktoberfest-2020-aqua-open-source) and [AquaSecurity Hacktoberfest repo](https://github.com/aquasecurity/Hacktoberfest) for more information and contribution guide.
 
 #### **ArchivesSpace** (ArchivesSpace bag)
 
 - **Requirements**: Be the contributor with the most merged PRs.
 - **Swag**: ArchivesSpace swag bag
-- **How to sign up**: Make PRs on [ArchivesSpace Github](https://github.com/archivesspace/archivesspace){:target="_blank"} and the top contributor will win the bag.
-- **Notes**: Check out [ArchivesSpace Hacktoberfest 2020 blog](https://archivesspace.org/archives/6563){:target="_blank"} for more information and help.
+- **How to sign up**: Make PRs on [ArchivesSpace Github](https://github.com/archivesspace/archivesspace) and the top contributor will win the bag.
+- **Notes**: Check out [ArchivesSpace Hacktoberfest 2020 blog](https://archivesspace.org/archives/6563) for more information and help.
 
 #### **Crio** (Goodie bag, t-shirt, and scholarship, India only)
 
 - **Requirements**: Top 50 performers
 - **Swag**: Crio bag of goodies and up to 50% scholarship
-- **How to sign up**: Fill out the form [here](https://crio.do/IBelieveInDoing/October/){:target="_blank"}.
-- **Notes**: For more details visit the dedicated [Hacktoberfest page](https://crio.do/IBelieveInDoing/October/){:target="_blank"} to get involved. Only eligible contributors residing in India will be shipped stickers and those making top 50 contributors will be shipped exclusive goodies, including a t-shirt.
+- **How to sign up**: Fill out the form [here](https://crio.do/IBelieveInDoing/October/).
+- **Notes**: For more details visit the dedicated [Hacktoberfest page](https://crio.do/IBelieveInDoing/October/) to get involved. Only eligible contributors residing in India will be shipped stickers and those making top 50 contributors will be shipped exclusive goodies, including a t-shirt.
 
 #### **Devfolio** (T-shirt, stickers, India only)
 
 - **Requirements**: 4 or more merged pull requests
 - **Swag**: T-shirt (limited to top 50 contributors), stickers
 - **How to sign up**: Contribute to any of the following GitHub repositories:
-  - [react-otp-input](https://github.com/devfolioco/react-otp-input){:target="_blank"}
-  - [react-copy-mailto](https://github.com/devfolioco/react-copy-mailto){:target="_blank"}
-  - [scrroll-in](https://github.com/devfolioco/scrroll-in){:target="_blank"}
-  - [devfolio-gatsby-starter](https://github.com/devfolioco/devfolio-gatsby-starter){:target="_blank"}.
-  - Fill out the [form](https://forms.gle/cp3EcPWzwyqW8fc68){:target="_blank"} before November 1st.
-- **Notes**: For more info visit [Devfolio's Hacktoberfest page](https://devfolio.co/blog/devfolio-hacktoberfest-2020). Only eligible contributors residing in India will be shipped stickers (including a limited edition Devfolio Hacktoberfest ones) and those making top 50 contributors will be shipped an exclusive t-shirt (within India only){:target="_blank"}.
+  - [react-otp-input](https://github.com/devfolioco/react-otp-input)
+  - [react-copy-mailto](https://github.com/devfolioco/react-copy-mailto)
+  - [scrroll-in](https://github.com/devfolioco/scrroll-in)
+  - [devfolio-gatsby-starter](https://github.com/devfolioco/devfolio-gatsby-starter).
+  - Fill out the [form](https://forms.gle/cp3EcPWzwyqW8fc68) before November 1st.
+- **Notes**: For more info visit [Devfolio's Hacktoberfest page](https://devfolio.co/blog/devfolio-hacktoberfest-2020). Only eligible contributors residing in India will be shipped stickers (including a limited edition Devfolio Hacktoberfest ones) and those making top 50 contributors will be shipped an exclusive t-shirt (within India only).
 
 #### **DX Heroes** (T-shirt, stickers, notebook, bottle opener)
 
 - **Requirements**: Be the contributor with the most merged PRs.
 - **Swag**: T-shirt, stickers, notebook, bottle opener
-- **How to sign up**: Please, fill out this [DX Heroes Hacktoberfest2020 Participant Form](https://forms.gle/76mPo9DoTLXmrHpU6) first. Then just visit one of the open source projects - [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content) or [DX Scanner](https://github.com/DXHeroes/dx-scanner){:target="_blank"}, make a pull request and compete with other contributors in the friendly competition to earn your place in the Leaderboard of Contributors.
-- **Notes**: If you have any questions or need help with anything, join the [Community Slack](https://bit.ly/slack_developer_experience){:target="_blank"}. They will gladly help you. Happy Hacktoberfest 2020!
+- **How to sign up**: Please, fill out this [DX Heroes Hacktoberfest2020 Participant Form](https://forms.gle/76mPo9DoTLXmrHpU6) first. Then just visit one of the open source projects - [DX Knowledge Base](https://github.com/DXHeroes/knowledge-base-content) or [DX Scanner](https://github.com/DXHeroes/dx-scanner), make a pull request and compete with other contributors in the friendly competition to earn your place in the Leaderboard of Contributors.
+- **Notes**: If you have any questions or need help with anything, join the [Community Slack](https://bit.ly/slack_developer_experience). They will gladly help you. Happy Hacktoberfest 2020!
 
 #### **InfraCloud** (T-shirt, stickers, Kindle)
 
-- **Requirements**: Be the top contributor with merged pull requests on [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube){:target="_blank"}.
+- **Requirements**: Be the top contributor with merged pull requests on [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube).
 - **Swag**: T-shirt, stickers, Kindle
-- **How to sign up**: Make the most number of PRs on InfraCloud's open-source projects – [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube). To deliver the swags, we will reach out to you once PR(s){:target="_blank"} gets merged.
-- **Notes**: A person with maximum merged PRs will also get a Kindle. Check out [InfraCloud official page](https://www.infracloud.io/infracloud-joins-hacktoberfest-2020/) for more info and join [Fission’s Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE) and [BotKube’s Slack](http://join.botkube.io/){:target="_blank"}.
+- **How to sign up**: Make the most number of PRs on InfraCloud's open-source projects – [Fission](https://github.com/fission/fission) and [BotKube](https://github.com/infracloudio/botkube). To deliver the swags, we will reach out to you once PR(s) gets merged.
+- **Notes**: A person with maximum merged PRs will also get a Kindle. Check out [InfraCloud official page](https://www.infracloud.io/infracloud-joins-hacktoberfest-2020/) for more info and join [Fission’s Slack](https://join.slack.com/t/fissionio/shared_invite/enQtOTI3NjgyMjE5NzE3LTllODJiODBmYTBiYWUwMWQxZWRhNDhiZDMyN2EyNjAzMTFiYjE2Nzc1NzE0MTU4ZTg2MzVjMDQ1NWY3MGJhZmE) and [BotKube’s Slack](http://join.botkube.io/).
 
 #### **MayaData** (T-shirt, stickers, laptop, mechanical keyboard, NVMe drive, wireless earbuds)
 
@@ -838,28 +838,28 @@ For more information regarding this click [here](https://hacktoberfest.digitaloc
   - 1+ merged PR: T-shirt and sticker
   - Top contributors: Laptop, mechanical keyboard, NVMe Drive or wireless earbuds
 - **Swag**: Laptop, mechanical keyboard, NVMe Drive, or wireless earbuds. Also get T-shirt and stickers.
-- **How to sign up**: Fill form from the link you will receive once your PR is merged. PR can be from [OpenEBS](https://github.com/openebs/openebs) or [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest){:target="_blank"}.
-- **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest){:target="_blank"}
-- **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata){:target="_blank"}.
+- **How to sign up**: Fill form from the link you will receive once your PR is merged. PR can be from [OpenEBS](https://github.com/openebs/openebs) or [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest).
+- **Issues**: [OpenEBS](https://github.com/openebs/openebs/labels/Hacktoberfest), [LitmusChaos](https://github.com/litmuschaos/litmus/labels/Hacktoberfest)
+- **Notes**: Check out the [MayaData Hacktoberfest blog post](https://blog.mayadata.io/celebrate-hacktoberfest-2020-open-source-with-mayadata).
 
 #### **Parabeac-Core** (T-shirt)
 
-- **Requirements**:Be among the top 100 contributors for the month on [Parabeac-Core](https://github.com/Parabeac/Parabeac-Core){:target="_blank"}.
+- **Requirements**:Be among the top 100 contributors for the month on [Parabeac-Core](https://github.com/Parabeac/Parabeac-Core).
 - **Swag**: T-shirt
 - **How to sign up**: You'll be contacted if you're among the top 100 for the month.
-- **Notes**: Check their [official post](https://dev.to/parabeac/hacktoberfest-parabeac-open-source-design-to-flutter-code-1jg0){:target="_blank"} to learn more.
+- **Notes**: Check their [official post](https://dev.to/parabeac/hacktoberfest-parabeac-open-source-design-to-flutter-code-1jg0) to learn more.
 
 #### **Stack Builders** (gift cards)
 
 - **Swag**: 9 gift cards
 - **Requirements**: Top contributors
-- **How to sign up**: Submit PRs to [StackBuilders GitHub](https://github.com/stackbuilders) and [fill up this form](https://docs.google.com/forms/d/e/1FAIpQLSc4QyXBUKf0nGvPdW6RaY2FJnIC45LkUsmoIZgCW6i1Jrliag/viewform){:target="_blank"}. Judges will review PRs and select the PRs depending on project size and relevance in the industry, the complexity of your contribution, the PR number and the quality code.
-- **Notes**: Check [Stackbuilders hacktoberfest blog](https://www.stackbuilders.com/news/join-us-for-our-first-hacktoberfest) for more information. Join [Stackbuilders Discord](https://discord.com/invite/S4QzFe8){:target="_blank"} to ask your doubts and talk about the event or your progress.
+- **How to sign up**: Submit PRs to [StackBuilders GitHub](https://github.com/stackbuilders) and [fill up this form](https://docs.google.com/forms/d/e/1FAIpQLSc4QyXBUKf0nGvPdW6RaY2FJnIC45LkUsmoIZgCW6i1Jrliag/viewform). Judges will review PRs and select the PRs depending on project size and relevance in the industry, the complexity of your contribution, the PR number and the quality code.
+- **Notes**: Check [Stackbuilders hacktoberfest blog](https://www.stackbuilders.com/news/join-us-for-our-first-hacktoberfest) for more information. Join [Stackbuilders Discord](https://discord.com/invite/S4QzFe8) to ask your doubts and talk about the event or your progress.
 
-Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/){:target="_blank"} or any company offering swag.
+Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/) or any company offering swag.
 
-![Presented by DigitalOcean, Intel, and Dev.to](img/SponsorsDarkBoxed.svg){:target="_blank"}
+![Presented by DigitalOcean, Intel, and Dev.to](img/SponsorsDarkBoxed.svg)
 
 ---
 
-If you're looking for the Swag List from 2018 and 2019, [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases) for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags) for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018) and [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019){:target="_blank"} branches.
+If you're looking for the Swag List from 2018 and 2019, [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases) for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags) for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018) and [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019) branches.


### PR DESCRIPTION
Reverts crweiner/hacktoberfest-swag-list#356

The {:target="_blank"} text appears in plain text on many links, both on GitHub and the rendered Jekyll page.