### PR TITLE
Fix broken links to some contributing users (and add mine :P )

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -145,9 +145,10 @@ If your contribution or PR is not formatted correctly, I'll let you know and giv
 - [Rohit Mathew](https://github.com/rohitjmathew)
 - [Aditya Vats](https://github.com/avats-dev)
 - [Pedro Fracassi](https://github.com/pedrofracassi)
-- [The HungryCoder](github.com/thehungrycoder)
-- [Guillaume Falourd](github.com/GuillaumeFalourd)
-- [Sudhanshu Tiwari](github.com/sudhanshutiwari264)
+- [The HungryCoder](https://github.com/thehungrycoder)
+- [Guillaume Falourd](https://github.com/GuillaumeFalourd)
+- [Sudhanshu Tiwari](https://github.com/sudhanshutiwari264)
+- [Bharat Raghunathan](https://github.com/Bharat123rox)
 
 Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/) or any company offering swag.
 


### PR DESCRIPTION
Thanks for contributing to the [Hacktoberfest Swag List](https://hacktoberfestswaglist.com/) :smiley: :tada:! Before submitting your pull request, please check off as many of the items below as you can:

1. [x] I have read the [Contributing.md](../CONTRIBUTING.md) file and formatted this PR correctly
2. [x] I'm not adding a company from the blocklist
3. [x] I make sure to fix things promptly if an error or suggestion comes up

Thanks and Happy Hacktoberfest! :tada:
Tagging @crweiner to take a look. :eyes:

Hey, though this may look minor/spammy just to add my name, it is *NOT*. The links to the user profile pages **were actually broken** since they were being treated as relative URLs prior to adding this `https://` prefix

Genuinely wanted to add this on as part of earlier PR #357 but I noticed it had already got merged just now 😅 