### PR TITLE
add metadata for URL sharing (og:image)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -3,6 +3,8 @@ logo: /img/Hacktoberfest_21.jpg
 description: There are many companies giving out free swag for Hacktoberfest and this list seeks to find them all!
 show_downloads: false
 url: "https://hacktoberfestswaglist.com"
+twitter:
+  card: summary
 google_analytics: "UA-129265975-1"
 remote_theme: "pages-themes/minimal"
 plugins:
@@ -17,3 +19,9 @@ exclude:
   - LICENSE
   - CNAME
 repository: "crweiner/hacktoberfest-swag-list"
+
+defaults:
+  - scope:
+      path: ""
+    values:
+      image: /img/Hacktoberfest_21.jpg


### PR DESCRIPTION
closes #384 

the image cannot be set as a property on the root `_config.yml`, it must be [set as a default image](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/advanced-usage.md#setting-a-default-image)

I would also suggest you add some [Author information](https://github.com/jekyll/jekyll-seo-tag/blob/master/docs/advanced-usage.md#author-information), but I will leave that to you @crweiner 