### PR TITLE
Use markdown_link_attr_modifier Python Plugin

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ verify_ssl = true
 
 [packages]
 mkdocs = "==1.4.0"
-mkdocs-material = "==8.5.3"
+mkdocs-material = "==8.5.6"
 python-markdown-math = "==0.8"
 Pygments = "==2.13.0"
 prompt_toolkit = "==3.0.31"
@@ -13,6 +13,7 @@ pyyaml = "==6.0"
 Jinja2 = "==3.1.2"
 pillow = "*"
 cairosvg = "*"
+markdown3-newtab = "*"
 
 [dev-packages]
 invoke = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -13,7 +13,7 @@ pyyaml = "==6.0"
 Jinja2 = "==3.1.2"
 pillow = "*"
 cairosvg = "*"
-markdown3-newtab = "*"
+markdown-link-attr-modifier = "*"
 
 [dev-packages]
 invoke = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e7ba0004d642b87a26c27c2aa328c2f385e5c96f734efc25037a8b5d54d6d192"
+            "sha256": "23d3fa87fa7c45ece7e7383479e83fb2951fdee890d9f9e46fb6ba01f0211356"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -20,6 +20,7 @@
             "hashes": [
                 "sha256:509339b32ccd8d7b00c2204c32736cde78db53a32e6a162d312478d25626cd9a"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==1.4.0"
         },
         "cairosvg": {
@@ -35,6 +36,7 @@
                 "sha256:0d9c601124e5a6ba9712dbc60d9c53c21e34f5f641fe83002317394311bdce14",
                 "sha256:90c1a32f1d68f940488354e36370f6cca89f0f106db09518524c88d6ed83f382"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2022.9.24"
         },
         "cffi": {
@@ -111,6 +113,7 @@
                 "sha256:5a3d016c7c547f69d6f81fb0db9449ce888b418b5b9952cc5e6e66843e9dd845",
                 "sha256:83e9a75d1911279afd89352c68b45348559d1fc0506b054b346651b5e7fee29f"
             ],
+            "markers": "python_full_version >= '3.6.0'",
             "version": "==2.1.1"
         },
         "click": {
@@ -118,6 +121,7 @@
                 "sha256:7682dc8afb30297001674575ea00d1814d808d6a36af415a82bd481d37ba7b8e",
                 "sha256:bb4d8133cb15a609f44e8213d9b391b0809795062913b383c62be0ee95b1db48"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==8.1.3"
         },
         "cssselect2": {
@@ -125,6 +129,7 @@
                 "sha256:1ccd984dab89fc68955043aca4e1b03e0cf29cad9880f6e28e3ba7a74b14aa5a",
                 "sha256:fd23a65bfd444595913f02fc71f6b286c29261e354c41d722ca7a261a49b5969"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==0.7.0"
         },
         "defusedxml": {
@@ -132,6 +137,7 @@
                 "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69",
                 "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4'",
             "version": "==0.7.1"
         },
         "ghp-import": {
@@ -146,15 +152,16 @@
                 "sha256:814f528e8dead7d329833b91c5faa87d60bf71824cd12a7530b5526063d02cb4",
                 "sha256:90b77e79eaa3eba6de819a0c442c0b4ceefc341a7a2ab77d7562bf49f425c5c2"
             ],
+            "markers": "python_version >= '3.5'",
             "version": "==3.4"
         },
         "importlib-metadata": {
             "hashes": [
-                "sha256:637245b8bab2b6502fcbc752cc4b7a6f6243bb02b31c5c26156ad103d3d45670",
-                "sha256:7401a975809ea1fdc658c3aa4f78cc2195a0e019c5cbc4c06122884e9ae80c23"
+                "sha256:da31db32b304314d044d3c12c79bd59e307889b287ad12ff387b3500835fc2ab",
+                "sha256:ddb0e35065e8938f867ed4928d0ae5bf2a53b7773871bfe6bcc7e4fcdc7dea43"
             ],
             "markers": "python_version < '3.10'",
-            "version": "==4.12.0"
+            "version": "==5.0.0"
         },
         "jinja2": {
             "hashes": [
@@ -169,7 +176,16 @@
                 "sha256:cbb516f16218e643d8e0a95b309f77eb118cb138d39a4f27851e6a63581db874",
                 "sha256:f5da449a6e1c989a4cea2631aa8ee67caa5a2ef855d551c88f9e309f4634c621"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==3.3.7"
+        },
+        "markdown3-newtab": {
+            "hashes": [
+                "sha256:4379eee3a8b4ced2908c7826a05ab3d87f3c36dbf90fca7e02bbe225d454502b",
+                "sha256:481d2cbaf392b1d86f835d9c5aa606ace235f533d4ad0b283c90454c714e5db2"
+            ],
+            "index": "pypi",
+            "version": "==0.2.0"
         },
         "markupsafe": {
             "hashes": [
@@ -214,6 +230,7 @@
                 "sha256:f121a1420d4e173a5d96e47e9a0c0dcff965afdf1626d28de1460815f7c4ee7a",
                 "sha256:fc7b548b17d238737688817ab67deebb30e8073c95749d55538ed473130ec0c7"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==2.1.1"
         },
         "mergedeep": {
@@ -221,6 +238,7 @@
                 "sha256:0096d52e9dad9939c3d975a774666af186eda617e6ca84df4c94dec30004f2a8",
                 "sha256:70775750742b25c0d8f36c55aed03d24c3384d17c951b3175d898bd778ef0307"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.3.4"
         },
         "mkdocs": {
@@ -233,17 +251,18 @@
         },
         "mkdocs-material": {
             "hashes": [
-                "sha256:43b0aa707d6f9acd836024cab2dce9330957c94a4e1e41c23ee6c8ce67b4d8c5",
-                "sha256:d194c38041d1e83560221022b3f85eec4604b35e44f5c3a488c24b88542074ed"
+                "sha256:38a21d817265d0c203ab3dad64996e45859c983f72180f6937bd5540a4eb84e4",
+                "sha256:b473162c800321b9760453f301a91f7cb40a120a85a9d0464e1e484e74b76bb2"
             ],
             "index": "pypi",
-            "version": "==8.5.3"
+            "version": "==8.5.6"
         },
         "mkdocs-material-extensions": {
             "hashes": [
                 "sha256:a82b70e533ce060b2a5d9eb2bc2e1be201cf61f901f93704b4acf6e3d5983a44",
                 "sha256:bfd24dfdef7b41c312ede42648f9eb83476ea168ec163b613f9abd12bbfddba2"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.0.3"
         },
         "packaging": {
@@ -251,6 +270,7 @@
                 "sha256:dd47c42927d89ab911e606518907cc2d3a1f38bbd026385970643f9c5b8ecfeb",
                 "sha256:ef103e05f519cdc783ae24ea4e2e0f508a9c99b2d4969652eed6a2e1ea5bd522"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==21.3"
         },
         "pillow": {
@@ -345,6 +365,7 @@
                 "sha256:1e36490adc7bfcef1fdb21bb0306e93af99cff8ec2db199bd17e3bf009768c11",
                 "sha256:b956b806439bbff10f726103a941266beb03fbe99f897c7d5e774d7170339ad9"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==9.6"
         },
         "pyparsing": {
@@ -352,6 +373,7 @@
                 "sha256:2b020ecf7d21b687f219b71ecad3631f644a47f01403fa1d1036b0c6416d70fb",
                 "sha256:5026bae9a10eeaefb61dab2f09052b9f4307d44aee4eda64b309723d8d206bbc"
             ],
+            "markers": "python_full_version >= '3.6.8'",
             "version": "==3.0.9"
         },
         "python-dateutil": {
@@ -359,6 +381,7 @@
                 "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
                 "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==2.8.2"
         },
         "python-markdown-math": {
@@ -420,6 +443,7 @@
                 "sha256:70092675bda14fdec33b31ba77e7543de9ddc88f2e5b99160396572d11525bdb",
                 "sha256:af31106dec8a4d68c60207c1886031cbf839b68aa7abccdb19868200532c2069"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==0.1"
         },
         "requests": {
@@ -427,6 +451,7 @@
                 "sha256:7c5599b102feddaa661c826c56ab4fee28bfd17f5abca1ebbe3e7f19d7c97983",
                 "sha256:8fefa2a1a1365bf5520aac41836fbee479da67864514bdb821f31ce07ce65349"
             ],
+            "markers": "python_version >= '3.7' and python_version < '4'",
             "version": "==2.28.1"
         },
         "six": {
@@ -434,6 +459,7 @@
                 "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
                 "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
         },
         "tinycss2": {
@@ -441,6 +467,7 @@
                 "sha256:b2e44dd8883c360c35dd0d1b5aad0b610e5156c2cb3b33434634e539ead9d8bf",
                 "sha256:fe794ceaadfe3cf3e686b22155d0da5780dd0e273471a51846d0a02bc204fec8"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==1.1.1"
         },
         "urllib3": {
@@ -448,6 +475,7 @@
                 "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e",
                 "sha256:b930dd878d5a8afb066a637fbb35144fe7901e3b209d1cd4f524bd0e9deee997"
             ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5' and python_version < '4'",
             "version": "==1.26.12"
         },
         "watchdog": {
@@ -478,6 +506,7 @@
                 "sha256:ed80a1628cee19f5cfc6bb74e173f1b4189eb532e705e2a13e3250312a62e0c9",
                 "sha256:ee3e38a6cc050a8830089f79cbec8a3878ec2fe5160cdb2dc8ccb6def8552658"
             ],
+            "markers": "python_version >= '3.6'",
             "version": "==2.1.9"
         },
         "wcwidth": {
@@ -499,6 +528,7 @@
                 "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
                 "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
             ],
+            "markers": "python_version >= '3.7'",
             "version": "==3.8.1"
         }
     },

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "23d3fa87fa7c45ece7e7383479e83fb2951fdee890d9f9e46fb6ba01f0211356"
+            "sha256": "cd0888718df317a7603cb282db8bc675563497497351a0fed70739ed74dfa808"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -179,10 +179,10 @@
             "markers": "python_version >= '3.6'",
             "version": "==3.3.7"
         },
-        "markdown3-newtab": {
+        "markdown-link-attr-modifier": {
             "hashes": [
-                "sha256:4379eee3a8b4ced2908c7826a05ab3d87f3c36dbf90fca7e02bbe225d454502b",
-                "sha256:481d2cbaf392b1d86f835d9c5aa606ace235f533d4ad0b283c90454c714e5db2"
+                "sha256:01b07d7a466ff7c721f97d66b08ec60a54e8d46c287695b649507ae57a42ff4b",
+                "sha256:94eacc4b7cfda9b5c883fb8c9f218b0602889c64d12977b31994d10b7b720a59"
             ],
             "index": "pypi",
             "version": "==0.2.0"

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -2,7 +2,7 @@
 
 We'd love it if you could help make the Hacktoberfest Swag List even better. That's the spirit of open source after all!
 
-Check [Issues](https://github.com/crweiner/hacktoberfest-swag-list/issues){:target="\_blank"} and current [Pull Requests](https://github.com/crweiner/hacktoberfest-swag-list/pulls){:target="\_blank"} before contributing to avoid adding duplicates.
+Check [Issues](https://github.com/crweiner/hacktoberfest-swag-list/issues) and current [Pull Requests](https://github.com/crweiner/hacktoberfest-swag-list/pulls) before contributing to avoid adding duplicates.
 
 Please follow these rules regarding how to add a new company to the List:
 
@@ -12,8 +12,8 @@ If you wish to add something to the Hacktoberfest Swag List, that's great and we
 
 Please be sure to follow the simple rules:
 
-1. Be sure you are looking to add something of substance to this project, not just spam PRs. PRs must meet the [Hacktoberfest Quality Standards](https://hacktoberfest.com/participation/){:target="\_blank"}.
-2. Verify that you have read the [home page](index.md), and [Readme.md on GitHub](https://github.com/crweiner/hacktoberfest-swag-list/blob/master/README.md){:target="\_blank"}. You understand that this project is to connect maintainers with developers, not a way to get all the swag you can.
+1. Be sure you are looking to add something of substance to this project, not just spam PRs. PRs must meet the [Hacktoberfest Quality Standards](https://hacktoberfest.com/participation/).
+2. Verify that you have read the [home page](index.md), and [Readme.md on GitHub](https://github.com/crweiner/hacktoberfest-swag-list/blob/master/README.md). You understand that this project is to connect maintainers with developers, not a way to get all the swag you can.
 3. Please be available to make changes within 48 hours when requested to do so. If you don't, then your PR may be closed.
 4. Please fix all issues flagged by the bots, including CodeClimate, GH Actions, Netlify, CircleCI or any others as soon as possible, ideally right away.
 5. A company must have publicly posted about their swag. You should include a link back to the original blog post, tweet, GitHub issue, etc. where the swag can be verified.
@@ -21,9 +21,9 @@ Please be sure to follow the simple rules:
 
 ## How to format your contribution
 
-Make a [fork of this repo](https://github.com/crweiner/hacktoberfest-swag-list/fork){:target="\_blank"} and add the details for what company and swag you find in the [list.md](/docs/list.md) file located at /docs/list.md.
+Make a [fork of this repo](https://github.com/crweiner/hacktoberfest-swag-list/fork) and add the details for what company and swag you find in the [list.md](/docs/list.md) file located at /docs/list.md.
 
-We are using a very simple language called Markdown to format this list. It's basically a way to make things look pretty without having to use a rich text editor. Please familiarize yourself with Markdown [using this handy cheat sheet provided by GitHub](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf){:target="\_blank"}
+We are using a very simple language called Markdown to format this list. It's basically a way to make things look pretty without having to use a rich text editor. Please familiarize yourself with Markdown [using this handy cheat sheet provided by GitHub](https://guides.github.com/pdfs/markdown-cheatsheet-online.pdf)
 
 New for 2022, we are only adding companies in an A->Z list and do not have a "Least Involvement to Most Involvement" section anymore. Why? Because this repo isn't about doing the least amount of effort to get a sticker or socks, it's about connecting you to companies who go above and beyond for Hacktoberfest. Thus, only an alphabetical list will be maintained this year.
 
@@ -37,7 +37,7 @@ Find the first letter of your company within the list, then add your information
 - **Swag**: (T-shirt, stickers, etc)
 - **Requirements**: What do I have to complete? Are there different requirements per swag item? Are the PRs merged or just submitted?
     - Indented lists require a Tab or 4 spaces instead of 2 spaces due to MkDocs formatting weirdness.
-- **How to sign up**: Link to signup page using inline formatting of [text](URL){:target="\_blank"}
+- **How to sign up**: Link to signup page using inline formatting of [text](URL)
 - **Issues**: Optional link to Hacktoberfest tagged issues.
 - **Notes**: If needed, otherwise write "N/A". This is where links to blog posts/tweets go.
 ```
@@ -56,10 +56,10 @@ Find the first letter of your company within the list, then add your information
 
 ---
 
-Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/){:target="\_blank"} or any company offering swag.
+Disclaimer: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/) or any company offering swag.
 
 ![Presented by DigitalOcean](img/Hfest-Badge-2-Color-Manga.svg)
 
 ---
 
-If you're looking for the Swag List from 2018 through 2021 [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases){:target="\_blank"} for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags){:target="\_blank"} for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018){:target="\_blank"}, [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019){:target="\_blank"}, [2020](https://github.com/crweiner/hacktoberfest-swag-list/tree/2020){:target="\_blank"}, and [2021](https://github.com/crweiner/hacktoberfest-swag-list/tree/2021){:target="\_blank"} branches.
+If you're looking for the Swag List from 2018 through 2021 [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases) for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags) for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018), [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019), [2020](https://github.com/crweiner/hacktoberfest-swag-list/tree/2020), and [2021](https://github.com/crweiner/hacktoberfest-swag-list/tree/2021) branches.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,32 +4,32 @@
 
 [![Hacktoberfest 2022 Banner](img/Hfest-Logo-2-Color-Manga.png)](list.md)
 
-Hello all you beautiful nerds and welcome to another year of [Hacktoberfest](https://hacktoberfest.com/){:target="\_blank"}!
+Hello all you beautiful nerds and welcome to another year of [Hacktoberfest](https://hacktoberfest.com/)!
 
-[As the official website states](https://hacktoberfest.com/#prepare-to-hack){:target="\_blank"}, Hacktoberfest is a time for everyone to celebrate open-source and come together to make meaningful contributions towards software and organizations you love. Whether this is your first Hacktoberfest or your 9th, everyone can contribute to making open-source software even better!
+[As the official website states](https://hacktoberfest.com/#prepare-to-hack), Hacktoberfest is a time for everyone to celebrate open-source and come together to make meaningful contributions towards software and organizations you love. Whether this is your first Hacktoberfest or your 9th, everyone can contribute to making open-source software even better!
 
-New for 2022, [low-code or no-code contributions are encouraged](https://hacktoberfest.com/about/#low-or-non-code){:target="\_blank"}, so everyone has a chance, regardless of skill level, to contribute and make open-source projects even better!
+New for 2022, [low-code or no-code contributions are encouraged](https://hacktoberfest.com/about/#low-or-non-code), so everyone has a chance, regardless of skill level, to contribute and make open-source projects even better!
 
 ---
 
 ## Sponsored By:
 
-[![Appwrite](img/appwrite-logo-1.svg)](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest){:target="\_blank"}
+[![Appwrite](img/appwrite-logo-1.svg)](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest)
 
-[Appwrite](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest){:target="\_blank"} is a proud sponsor of _all of Hacktoberfest_, as well as the Hacktoberfest Swag List! They understand the importance of connecting developers to open-source projects that could use some help.
+[Appwrite](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest) is a proud sponsor of _all of Hacktoberfest_, as well as the Hacktoberfest Swag List! They understand the importance of connecting developers to open-source projects that could use some help.
 Appwrite is a self-hosted backend-as-a-service platform that provides developers with all the core APIs required to build any application.
 
 ---
 
 ## What is the Hacktoberfest Swag List?
 
-This site and [GitHub repo](https://github.com/crweiner/hacktoberfest-swag-list){:target="\_blank"} are here to showcase all of the amazing companies that go above and beyond by offering their own swag for the holiday. **The goal of this project is to connect contributors to open-source projects that they might not have heard about before and drive traffic towards organizations that celebrate Hacktoberfest and can use a little more help.**
+This site and [GitHub repo](https://github.com/crweiner/hacktoberfest-swag-list) are here to showcase all of the amazing companies that go above and beyond by offering their own swag for the holiday. **The goal of this project is to connect contributors to open-source projects that they might not have heard about before and drive traffic towards organizations that celebrate Hacktoberfest and can use a little more help.**
 
 ### This website/repo is not about collecting all of the swag you can. It is about the _open-source community_ and highlighting organizations that purposely want to drive traffic to their projects during Hacktoberfest by offering unique swag
 
 ### Swag is an added benefit of helping out these awesome organizations, not the reason for you to contribute in the first place
 
-Participating in Hacktoberfest requires following the [official values](https://hacktoberfest.com/participation/#values){:target="\_blank"}, including [**not spamming** the participating companies](https://hacktoberfest.com/participation/#spam){:target="\_blank"}.
+Participating in Hacktoberfest requires following the [official values](https://hacktoberfest.com/participation/#values), including [**not spamming** the participating companies](https://hacktoberfest.com/participation/#spam).
 
 ---
 
@@ -41,10 +41,10 @@ This year, the Swag List is a little different, so be sure to read about how to 
 
 ---
 
-_Disclaimer_: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.com/){:target="\_blank"} or any company offering swag.
+_Disclaimer_: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.com/) or any company offering swag.
 
 ![Presented by DigitalOcean](img/Hfest-Badge-2-Color-Manga.svg)
 
 ---
 
-If you're looking for the Swag List from 2018 through 2021 [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases){:target="\_blank"} for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags){:target="\_blank"} for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018){:target="\_blank"}, [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019){:target="\_blank"}, [2020](https://github.com/crweiner/hacktoberfest-swag-list/tree/2020){:target="\_blank"}, and [2021](https://github.com/crweiner/hacktoberfest-swag-list/tree/2021){:target="\_blank"} branches.
+If you're looking for the Swag List from 2018 through 2021 [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases) for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags) for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018), [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019), [2020](https://github.com/crweiner/hacktoberfest-swag-list/tree/2020), and [2021](https://github.com/crweiner/hacktoberfest-swag-list/tree/2021) branches.

--- a/docs/list.md
+++ b/docs/list.md
@@ -2,7 +2,7 @@
 
 ## Hacktoberfest is about making meaningful contributions to open source projects. SPAM for the sake of a T-shirt will not be tolerated
 
-First, [sign up for Hacktoberfest 2022 by clicking this link](https://hacktoberfest.com/){:target="\_blank"} Then, [read about how to participate in a meaningful way in the FAQ](https://hacktoberfest.com/participation/){:target="\_blank"}.
+First, [sign up for Hacktoberfest 2022 by clicking this link](https://hacktoberfest.com/) Then, [read about how to participate in a meaningful way in the FAQ](https://hacktoberfest.com/participation/).
 
 See [**Contributing.md**](./contributing.md) to see how to format your pull request to add a company's swag to the List!
 
@@ -12,9 +12,9 @@ See [**Contributing.md**](./contributing.md) to see how to format your pull requ
 
 ## Sponsored By:
 
-[![Appwrite](img/appwrite-logo-1.svg)](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest){:target="\_blank"}
+[![Appwrite](img/appwrite-logo-1.svg)](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest)
 
-[Appwrite](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest){:target="\_blank"} is a proud sponsor of *all of Hacktoberfest*, as well as the Hacktoberfest Swag List! They understand the importance of connecting developers to open-source projects that could use some help.
+[Appwrite](https://hacktoberfest.appwrite.io/?utm_source=web&utm_medium=swaglist&utm_campaign=hacktoberfest) is a proud sponsor of *all of Hacktoberfest*, as well as the Hacktoberfest Swag List! They understand the importance of connecting developers to open-source projects that could use some help.
 Appwrite is a self-hosted backend-as-a-service platform that provides developers with all the core APIs required to build any application.
 
 ---
@@ -24,8 +24,8 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 ### **The Original - DigitalOcean, Appwrite, and Docker**
 
 - **Swag**: T-shirt, stickers
-- **Requirements**: 4 pull requests in any eligible [repository](https://github.com/topics/hacktoberfest){:target="\_blank"}
-- **How to sign up**: [Hacktoberfest Website](https://hacktoberfest.com){:target="\_blank"}
+- **Requirements**: 4 pull requests in any eligible [repository](https://github.com/topics/hacktoberfest)
+- **How to sign up**: [Hacktoberfest Website](https://hacktoberfest.com)
 - **Notes**: For your PR to count it must be:
   - Submitted in a public repo, AND
     - The PR is labelled as ```hacktoberfest-accepted``` by a maintainer, OR
@@ -45,13 +45,13 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
      - Third place will receive $750 and exclusive Airbyte bronze swag pack.
      - Anyone who submits a connector within the event dates will receive $500 and Airbyte swag
 - **Requirements**:
-     - Must follow all guidelines on the project repo [Guidelines.md](https://github.com/airbytehq/connector-contest/blob/main/GUIDELINES.md){:target="\_blank"}.
+     - Must follow all guidelines on the project repo [Guidelines.md](https://github.com/airbytehq/connector-contest/blob/main/GUIDELINES.md).
      - PRs merged before 2nd Of November 2022 only will be taken in consideration.
      - Must have proper documentation for getting started and usage.
      - Must include a sandbox account for integration tests.
-- **How to sign up**:  Check out the [Airbyte webiste](https://airbyte.com/connector-contest){:target="\_blank"} for more details.
-- **Issues**: Their [Hacktoberfest Issues](https://github.com/airbytehq/connector-contest/issues){:target="\_blank"} are tagged here.
-- **Notes**: Join their [Hacktoberfest Slack channel](https://join.slack.com/share/enQtNDEzMjUzNTQ5OTg0Ny0xN2I2MDU4NGFkOTNlYzZlN2JmMGIzOTgyMjU1ODk1MDIzZWM5YTAzMThkMDFkNzgzNWNjNzljOGU1MmRhMDIw){:target="\_blank"}.
+- **How to sign up**:  Check out the [Airbyte webiste](https://airbyte.com/connector-contest) for more details.
+- **Issues**: Their [Hacktoberfest Issues](https://github.com/airbytehq/connector-contest/issues) are tagged here.
+- **Notes**: Join their [Hacktoberfest Slack channel](https://join.slack.com/share/enQtNDEzMjUzNTQ5OTg0Ny0xN2I2MDU4NGFkOTNlYzZlN2JmMGIzOTgyMjU1ODk1MDIzZWM5YTAzMThkMDFkNzgzNWNjNzljOGU1MmRhMDIw).
 
 #### **Amplication**
 
@@ -96,9 +96,9 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - 2 Contributions : Limited Edition Appwrite Hacktoberfest + OG stickers.
     - 3 Contributions : Limited Edition Hacktoberfest sticker pack + 2 packs of stickers.
     - 4 Contributions and more : Limited Edition Appwrite Hacktoberfest T-shirt.
-- **How to sign up**: Check out the [Appwrite website](https://hacktoberfest.appwrite.io/){:target="\_blank"} for more details.
-- **Issues**: List of [Hacktoberfest Labelled Issues](https://github.com/search?q=org%3Aappwrite+org%3Autopia-php+org%3Aopen-runtimes+label%3Ahacktoberfest+created%3A%3E2021-01-01+state%3Aopen&type=issues&s=updated&o=asc){:target="\_blank"}.
-- **Notes**: Read the [blog post](https://appwrite.io/hacktoberfest){:target="\_blank"} for more info.
+- **How to sign up**: Check out the [Appwrite website](https://hacktoberfest.appwrite.io/) for more details.
+- **Issues**: List of [Hacktoberfest Labelled Issues](https://github.com/search?q=org%3Aappwrite+org%3Autopia-php+org%3Aopen-runtimes+label%3Ahacktoberfest+created%3A%3E2021-01-01+state%3Aopen&type=issues&s=updated&o=asc).
+- **Notes**: Read the [blog post](https://appwrite.io/hacktoberfest) for more info.
 
 #### **Aviyel**
 
@@ -107,20 +107,20 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Participants are requested to create technical content based on the theme of each week and submit it within the deadline.
     - Participants will be eligible for a prize only if they attend at least 2 workshops and make 3 submissions (one each week).
     - Submissions must be original work (Plagiarized content will not be accepted).
-- **How to sign up**: Sign up for the [Hacktoberfest with Aviyel form here](https://aviyel.typeform.com/register){:target="\_blank"}.
-- **Notes**: Additional information regarding Hacktoberfest with Aviyel [can be found in this blog post. It is very extensive, be sure to read it all to meet their qualifications.](https://aviyel.com/post/3738/announcing-hacktoberfest-with-aviyel){:target="\_blank"}.
+- **How to sign up**: Sign up for the [Hacktoberfest with Aviyel form here](https://aviyel.typeform.com/register).
+- **Notes**: Additional information regarding Hacktoberfest with Aviyel [can be found in this blog post. It is very extensive, be sure to read it all to meet their qualifications.](https://aviyel.com/post/3738/announcing-hacktoberfest-with-aviyel).
 
 ### B
 
 #### **Bagisto**
 
 - **Swag**: T-Shirt, Stickers, Notebook, Pen, and Bagisto Elephant
-- **Requirements**: Contribute to [Bagisto](https://github.com/bagisto/bagisto){:target="\_blank"} during the month of October and have 4 merged PRs to the Bagisto repo.
-- **How to sign up**: Check out the [Bagisto website](https://webkul.com/meetups/hacktober-fest-bagisto-2022/){:target="\_blank"} for more details.
-- **Issues**: [Hacktoberfest Labelled Issues](https://github.com/bagisto/bagisto/issues?q=is%3Aopen+is%3Aissue+label%3AHacktoberfest){:target="\_blank"}
+- **Requirements**: Contribute to [Bagisto](https://github.com/bagisto/bagisto) during the month of October and have 4 merged PRs to the Bagisto repo.
+- **How to sign up**: Check out the [Bagisto website](https://webkul.com/meetups/hacktober-fest-bagisto-2022/) for more details.
+- **Issues**: [Hacktoberfest Labelled Issues](https://github.com/bagisto/bagisto/issues?q=is%3Aopen+is%3Aissue+label%3AHacktoberfest)
 - **Notes**:
     - For the PR to count for Bagisto's unique swag, it must be accepted, marked with the `Hacktoberfest` label, and they have added a difficulty level.
-    - Read the [blog post for more info](https://webkul.com/meetups/hacktober-fest-bagisto-2022/){:target="\_blank"}.
+    - Read the [blog post for more info](https://webkul.com/meetups/hacktober-fest-bagisto-2022/).
 
 ### C
 
@@ -128,31 +128,31 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: Plant a tree, t-shirt
 - **Requirements**:
-    - Submit 4 quality pull requests to to any [Camunda repo](https://github.com/orgs/camunda/repositories){:target="\_blank"} or participating [Camunda Community Hub repos](https://github.com/orgs/camunda-community-hub/repositories){:target="\_blank"}. Look for the `hacktoberfest` label on the repo.
+    - Submit 4 quality pull requests to to any [Camunda repo](https://github.com/orgs/camunda/repositories) or participating [Camunda Community Hub repos](https://github.com/orgs/camunda-community-hub/repositories). Look for the `hacktoberfest` label on the repo.
     - The PRs must receive the `hacktoberfest-accepted` tag.
-    - They will also make a donation to [One Tree Planted](https://onetreeplanted.org/){:target="\_blank"} for each person that earns their t-shirt!
-- **How to sign up**: Once all 4 PRs are accepted, then [fill out the form here](https://camunda.com/hacktoberfest2022/){:target="\_blank"}.
-- **Notes**: Additional information regarding their Hacktoberfest participation [can be found on this page](https://camunda.com/hacktoberfest2022/){:target="\_blank"}.
+    - They will also make a donation to [One Tree Planted](https://onetreeplanted.org/) for each person that earns their t-shirt!
+- **How to sign up**: Once all 4 PRs are accepted, then [fill out the form here](https://camunda.com/hacktoberfest2022/).
+- **Notes**: Additional information regarding their Hacktoberfest participation [can be found on this page](https://camunda.com/hacktoberfest2022/).
 
 #### **Chimoney**
 
 - **Swag**: Credit, t-shirt
-- **Requirements**: Contribute to [Chimoney Community Projects repo](https://github.com/Chimoney/chimoney-community-projects){:target="\_blank"} during the month of October by tackling a `Hacktoberfest` labeled Issue, and have 4 merged PRs to the Chimoney repo.
+- **Requirements**: Contribute to [Chimoney Community Projects repo](https://github.com/Chimoney/chimoney-community-projects) during the month of October by tackling a `Hacktoberfest` labeled Issue, and have 4 merged PRs to the Chimoney repo.
 - **How to sign up**: You need to create a Chimoney account by following these steps:
-    - Create a organization on [Chimoney Dashboard](https://dash.chimoney.io){:target="\_blank"}.
+    - Create a organization on [Chimoney Dashboard](https://dash.chimoney.io).
     - Send [them an email](mailto:support@chimoney.io) with the name of the organization to approve.
     - Switch to the organization (top right) and go to dev page, you’ll see your keys. It’s `live keys`, for now. No test keys yet.
     - They will add $10 for testing. You can always send $1 to yourself to test and redeem it back to the organization. That way, you always have funds.
 - **Notes**:
     - 1 merged PR fixing a `Hacktoberfest` Issue = $25 credit.
     - 4 merged PRs fixing a `Hacktoberfest` Issue = T-shirt and $100 credit.
-    - More information [here](https://twitter.com/chimoney_io/status/1576286913723596803?s=48&t=JCGsKCKdKEB_sVfGml2m6w){:target="\_blank"} and on their [Community Repo](https://github.com/Chimoney/chimoney-community-projects){:target="\_blank"}.
+    - More information [here](https://twitter.com/chimoney_io/status/1576286913723596803?s=48&t=JCGsKCKdKEB_sVfGml2m6w) and on their [Community Repo](https://github.com/Chimoney/chimoney-community-projects).
 
 #### **Codedamn**
 
 - **Swag**: T-shirt
-- **Requirements**: During Hacktoberfest, submit an interactive project to [codedamn/projects repository](https://github.com/codedamn/projects){:target="\_blank"}.
-- **How to sign up**: [Please read their Readme file here very throughly](https://github.com/codedamn/projects#readme){:target="\_blank"}.
+- **Requirements**: During Hacktoberfest, submit an interactive project to [codedamn/projects repository](https://github.com/codedamn/projects).
+- **How to sign up**: [Please read their Readme file here very throughly](https://github.com/codedamn/projects#readme).
 - **Notes**: In order to participate and win prizes, you have to submit a guided project. A guided project is a breakdown of a project into multiple steps for a beginner/intermediate developer to build. These guided projects can be attempted for free from codedamn IDE.
 
 ### D
@@ -161,29 +161,29 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: Individual swags like t-shirt, stickers, or a full swag bundle, depending on the number of PRs (2 to 10).
 - **Requirements**: Contribute to one of the following (or both):
-     - Challenge 1: [Papers With Everything](https://github.com/DagsHub/papers-with-everything){:target="\_blank"}.
-     - Challenge 2: [3D Model Datasets](https://github.com/DagsHub/3D-model-datasets){:target="\_blank"}.
-- **How to sign up**: Sign up to [DagsHub](https://dagshub.com/user/sign_up?redirect_to=){:target="\_blank"}. Also, join their [Hacktoberfest Discord Channel](https://discord.gg/6SsqDCUVeq){:target="\_blank"}.
+     - Challenge 1: [Papers With Everything](https://github.com/DagsHub/papers-with-everything).
+     - Challenge 2: [3D Model Datasets](https://github.com/DagsHub/3D-model-datasets).
+- **How to sign up**: Sign up to [DagsHub](https://dagshub.com/user/sign_up?redirect_to=). Also, join their [Hacktoberfest Discord Channel](https://discord.gg/6SsqDCUVeq).
 - **Issues**: List of issues for contributing to:
-    - [Papers With Everything](https://github.com/DagsHub/papers-with-everything/issues){:target="\_blank"}.
-    - [3D Model Datasets](https://github.com/DagsHub/3D-model-datasets/issues){:target="\_blank"}.
-- **Notes**: Additional info regarding the contributions can be found [here](https://dagshub.com/blog/dagshub-x-hacktoberfest-2022/){:target="\_blank"}.
+    - [Papers With Everything](https://github.com/DagsHub/papers-with-everything/issues).
+    - [3D Model Datasets](https://github.com/DagsHub/3D-model-datasets/issues).
+- **Notes**: Additional info regarding the contributions can be found [here](https://dagshub.com/blog/dagshub-x-hacktoberfest-2022/).
 
 #### **devICT**
 
 - **Swag**: Stickers
 - **Requirements**: Create two PRs in any of the qualifying Wichita repos
-- **How to sign up**: Sign in with [Github here](https://devict-hacktoberfest.herokuapp.com/){:target="\_blank"} so they can track your PRs.
-- **Notes**: You need to create at least two PRs in any of the  Wichita developer community organizations listed [here](https://devict-hacktoberfest.herokuapp.com/){:target="\_blank"}
+- **How to sign up**: Sign in with [Github here](https://devict-hacktoberfest.herokuapp.com/) so they can track your PRs.
+- **Notes**: You need to create at least two PRs in any of the  Wichita developer community organizations listed [here](https://devict-hacktoberfest.herokuapp.com/)
 
 ### E
 
 #### **Encore**
 
 - **Swag**: A pack of 12 Encore stickers
-- **Requirements**: Build an app with Encore, tweet your Encore Flow diagram, or contribute to [encoredev/encore](https://github.com/encoredev/encore){:target="\_blank"}
-- **How to sign up**: Pick up a [GitHub Issue](https://github.com/encoredev/encore/issues){:target="\_blank"}, or check out the [Quick Start](https://encore.dev/docs/quick-start){:target="\_blank"} to build your first Encore app and once you're done post it in our Show & Tell!
-- **Notes**: [See the Hacktoberfest blog post and weekly Community Office Hours every Friday](https://community.encore.dev/t/our-new-office-hours-to-kick-off-hacktoberfest/66){:target="\_blank"}
+- **Requirements**: Build an app with Encore, tweet your Encore Flow diagram, or contribute to [encoredev/encore](https://github.com/encoredev/encore)
+- **How to sign up**: Pick up a [GitHub Issue](https://github.com/encoredev/encore/issues), or check out the [Quick Start](https://encore.dev/docs/quick-start) to build your first Encore app and once you're done post it in our Show & Tell!
+- **Notes**: [See the Hacktoberfest blog post and weekly Community Office Hours every Friday](https://community.encore.dev/t/our-new-office-hours-to-kick-off-hacktoberfest/66)
 
 ### F
 
@@ -195,9 +195,9 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Submit 3 pull requests and get them approved/merged to receive a Flyte t-shirt.
     - Contribute a plugin to receive a voucher.
     - Submit 3+ pull requests and get them approved/merged to receive The North Face® jacket.
-- **How to sign up**: Fill out this [form](https://tally.so/r/nWO7qQ){:target="\_blank"} after you are done with either of the challenges on or before Oct. 31, 2022. Join Flyte's #hacktoberfest-2022 [Slack](https://slack.flyte.org/){:target="\_blank"} channel in case you have queries.
-- **Issues**: List of [hacktoberfest-labeled issues](https://github.com/flyteorg/flyte/issues/2917){:target="\_blank"}
-- **Notes**: Check out the [blog post](https://blog.flyte.org/meet-flyte-and-unionml-at-hacktoberfest-2022){:target="\_blank"} for more info.
+- **How to sign up**: Fill out this [form](https://tally.so/r/nWO7qQ) after you are done with either of the challenges on or before Oct. 31, 2022. Join Flyte's #hacktoberfest-2022 [Slack](https://slack.flyte.org/) channel in case you have queries.
+- **Issues**: List of [hacktoberfest-labeled issues](https://github.com/flyteorg/flyte/issues/2917)
+- **Notes**: Check out the [blog post](https://blog.flyte.org/meet-flyte-and-unionml-at-hacktoberfest-2022) for more info.
 
 ### G
 
@@ -205,19 +205,19 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: HardCopy Of The Bhagavad Gita And Stickers
 - **Requirements**: Submit 4 PRs and have them merged/accepted.
-- **How to sign up**: Add values on the [Gita Initiative repo](https://github.com/gita/gita){:target="\_blank"}.
-- **Notes**: Check out this [link](https://www.linkedin.com/posts/vedvyas_github-gitagita-bhagavad-gita-in-json-activity-6982314384161140736-o370/){:target="\_blank"} for more info.
+- **How to sign up**: Add values on the [Gita Initiative repo](https://github.com/gita/gita).
+- **Notes**: Check out this [link](https://www.linkedin.com/posts/vedvyas_github-gitagita-bhagavad-gita-in-json-activity-6982314384161140736-o370/) for more info.
 
 ### H
 
 #### **Hasura**
 
 - **Swag**: T-shirt and stickers.
-- **Requirements**: Submit a PR to solve one or more issues in [Hasura GraphQL Engine](https://github.com/hasura/graphql-engine){:target="\_blank"} or [Hasura’s Learn tutorials](https://github.com/hasura/learn-graphql){:target="\_blank"}.
+- **Requirements**: Submit a PR to solve one or more issues in [Hasura GraphQL Engine](https://github.com/hasura/graphql-engine) or [Hasura’s Learn tutorials](https://github.com/hasura/learn-graphql).
     - PR for a small fix (example: a typo fix) will only qualify for a sticker pack.
 - **How to sign up**: An order form link will be sent to you via your PR's comment section.
-- **Issues**: [learn-graphql issues](https://github.com/hasura/learn-graphql/issues){:target="\_blank"} and [graphql-engine issues](https://github.com/hasura/graphql-engine/issues){:target="\_blank"}.
-- **Notes**: For more information, check out [this blog post](https://hasura.io/blog/hasura-joins-hacktoberfest-3rd-year-in-a-row/){:target="\_blank"} and [this blog post too](https://hasura.io/blog/with-hasura-celebrate-open-source-in-style-with-hacktoberfest/){:target="\_blank"}.
+- **Issues**: [learn-graphql issues](https://github.com/hasura/learn-graphql/issues) and [graphql-engine issues](https://github.com/hasura/graphql-engine/issues).
+- **Notes**: For more information, check out [this blog post](https://hasura.io/blog/hasura-joins-hacktoberfest-3rd-year-in-a-row/) and [this blog post too](https://hasura.io/blog/with-hasura-celebrate-open-source-in-style-with-hacktoberfest/).
 
 ### I
 
@@ -230,9 +230,9 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Submit 5 to 10 pull requests and get them approved/merged with tag **hacktoberfest-accepted** to receive a Zappy, FlutterVikings rubber duck, Flutter mug, T-shirt, stickers pack.
     - Submit 4 to 2 pull requests and get them approved/merged with tag **hacktoberfest-accepted** to receive a Flutter mug, T-shirt, stickers pack.
     - Submit 1 pull requests and get them approved/merged with tag **hacktoberfest-accepted** to receive a T-shirt, stickers pack.
-- **How to sign up**: Click the ["Sign up with Github" button here](https://invertase.io/community/hacktoberfest){:target="\_blank"} before you start with the challenges on or before Oct. 31, 2022.
-- **Issues**: See the list of [hacktoberfest-labeled issues](https://github.com/search?q=org%3Ainvertase+org%3Afluttercommunity+org%3Aatsign-foundation++label%3Ahacktoberfest+created%3A%3E2021-01-01+state%3Aopen&type=Issues){:target="\_blank"}.
-- **Notes**: Check out the [website](https://invertase.io/community/hacktoberfest){:target="\_blank"} for more info.
+- **How to sign up**: Click the ["Sign up with Github" button here](https://invertase.io/community/hacktoberfest) before you start with the challenges on or before Oct. 31, 2022.
+- **Issues**: See the list of [hacktoberfest-labeled issues](https://github.com/search?q=org%3Ainvertase+org%3Afluttercommunity+org%3Aatsign-foundation++label%3Ahacktoberfest+created%3A%3E2021-01-01+state%3Aopen&type=Issues).
+- **Notes**: Check out the [website](https://invertase.io/community/hacktoberfest) for more info.
 
 ### L
 
@@ -245,8 +245,8 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - 3 Contributions : LambdaTest T-Shirt + Sticker pack
     - 5 Contributions and more : LambdaTest T-Shirt + Sticker pack + Bottle
 - **How to sign up**: Unsure how they are tracking signups at the moment.
-- **Issues**: List of [Hacktoberfest Labelled Issues](https://github.com/LambdaTest/test-at-scale-scripts/issues){:target="\_blank"}.
-- **Notes**: Read the [blog post](https://www.lambdatest.com/blog/celebrate-hacktoberfest-2022-with-lambdatest/){:target="\_blank"} for more info.
+- **Issues**: List of [Hacktoberfest Labelled Issues](https://github.com/LambdaTest/test-at-scale-scripts/issues).
+- **Notes**: Read the [blog post](https://www.lambdatest.com/blog/celebrate-hacktoberfest-2022-with-lambdatest/) for more info.
 
 #### LocalStack
 
@@ -259,8 +259,8 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Find a project with the Hacktoberfest tag
     - Contribute to the project by following the Hacktoberfest tag between Oct. 1 and Oct. 30
     - Follow-up if needed with maintainers about pull requests to make sure they are merged before Oct.30
-- **How to sign up**: Signup on the [Hacktoberfest website](https://hacktoberfest.com/){:target="\_blank"}
-- **Notes**: Checkout the [LocalStack post](https://localstack.cloud/blog/2022-10-01-contribute-to-open-source-with-localstack-hacktoberfest/){:target="\_blank"} for more info.
+- **How to sign up**: Signup on the [Hacktoberfest website](https://hacktoberfest.com/)
+- **Notes**: Checkout the [LocalStack post](https://localstack.cloud/blog/2022-10-01-contribute-to-open-source-with-localstack-hacktoberfest/) for more info.
 
 ### M
 
@@ -271,11 +271,11 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Everyone who makes one or more contributions to the Mattermost community during Hacktoberfest will receive a pack of custom Mattermost stickers.
     - They will select top contributors to receive a custom Mattermost t-shirt and mug.
 - **How to sign up**:
-    - Review the [issues here](https://github.com/search?q=org%3Amattermost+type%3Aissues+label%3A%22help+wanted%22&state=open&type=Issues){:target="\_blank"}.
+    - Review the [issues here](https://github.com/search?q=org%3Amattermost+type%3Aissues+label%3A%22help+wanted%22&state=open&type=Issues).
     - Browse the issues that are labeled `#hacktoberfest` in their repos and find an issue to tackle.
     - The Mattermost team will review the pull request and let you know if additional work is needed.
     - After they have merged your pull request(s), you can claim your swag.
-- **Notes**: More details for the Hackathon prizes and Hacktoberfest details [are on their blog here](https://mattermost.com/blog/hacktoberfest-2022/){:target="\_blank"} and their  [Hacktoberfest landing page here](https://mattermost.com/hacktoberfest/){:target="\_blank"}.
+- **Notes**: More details for the Hackathon prizes and Hacktoberfest details [are on their blog here](https://mattermost.com/blog/hacktoberfest-2022/) and their  [Hacktoberfest landing page here](https://mattermost.com/hacktoberfest/).
 
 #### **MedusaJS**
 
@@ -286,11 +286,11 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Submit 2 pull requests and get them merged to receive a Medusa t-shirt and stickers.
     - Submit 3 or more pull requests and get them merged to receive a Medusa t-shirt, stickers and water bottle.
 - **How to sign up**:
-    - Sign up for a [Hackathon here](https://ky5eo2x1u81.typeform.com/to/oG2DCRg7?typeform-source=hacktoberfestswaglist.com){:target="\_blank"} and review the [Hackathon details](https://github.com/medusajs/medusa/discussions/2280){:target="\_blank"}.
+    - Sign up for a [Hackathon here](https://ky5eo2x1u81.typeform.com/to/oG2DCRg7?typeform-source=hacktoberfestswaglist.com) and review the [Hackathon details](https://github.com/medusajs/medusa/discussions/2280).
     - Browse the issues that are labeled `#hacktoberfest` in their repos and find an issue to tackle.
     - The Medusa team will review the pull request and let you know if additional work is needed.
     - After they have merged your pull request(s), you can claim your swag.
-- **Notes**: More details for the Hackathon prizes and Hacktoberfest details [are here](https://medusajs.com/blog/medusa-hackathon){:target="\_blank"}.
+- **Notes**: More details for the Hackathon prizes and Hacktoberfest details [are here](https://medusajs.com/blog/medusa-hackathon).
 
 #### **Meilisearch**
 
@@ -320,13 +320,13 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: NFT and T-shirts
 - **Requirements**:
-    - Submit one or more pull requests to Metafy's repositories with the `hacktoberfest` label to qualify as a contributor. Top contributors will get their very own NFT and T-shirts from Metafy. Check out the [Documentation on their GitHub README File](https://github.com/metafy-social/.github/blob/main/profile/README.md){:target="\_blank"} for more details.
+    - Submit one or more pull requests to Metafy's repositories with the `hacktoberfest` label to qualify as a contributor. Top contributors will get their very own NFT and T-shirts from Metafy. Check out the [Documentation on their GitHub README File](https://github.com/metafy-social/.github/blob/main/profile/README.md) for more details.
 - **How to Sign up**:
-    - Register on the [Hacktoberfest website](https://hacktoberfest.com/){:target="\_blank"} anytime between September 26 and October 31, 2022.
+    - Register on the [Hacktoberfest website](https://hacktoberfest.com/) anytime between September 26 and October 31, 2022.
     - Contribute with PR/MRs to Metafy's `hacktoberfest` labelled repositories during the period from October 1 to October 31, 2022.
     - The Metafy team will review your PRs constantly and give you feedback.
 - **Notes**:
-    - Join the [Metafys's Discord Server](https://discord.com/invite/AqnaGBGAUt){:target="\_blank"} to find additional details or connect with Metafy's employees.
+    - Join the [Metafys's Discord Server](https://discord.com/invite/AqnaGBGAUt) to find additional details or connect with Metafy's employees.
 
 ### N
 
@@ -340,20 +340,20 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Most bugs closed (PRs opened and approved).
     - Most docs updated (PRs opened and approved).
 - **How to sign up**: To participate in Hacktoberfest there's no need to sign up, all you need to do is submit pull request(s) for a qualifying repo.
-- **Notes**: Check out [here](https://blog.networktocode.com/post/hackathon/){:target="\_blank"} for more info.
+- **Notes**: Check out [here](https://blog.networktocode.com/post/hackathon/) for more info.
 
 #### **Novu**
 
 - **Swag**: T-shirt, Sticker Pack.
 - **Requirements**:
-    - Submit 3 pull requests to the [Novu repository](https://github.com/novuhq/novu){:target="\_blank"} and get them merged to receive the Special Novu swag pack.
+    - Submit 3 pull requests to the [Novu repository](https://github.com/novuhq/novu) and get them merged to receive the Special Novu swag pack.
 - **How to sign up**:
     - No Special Sign-ups required.
-    - You can simply visit their repository [here](https://github.com/novuhq/novu){:target="\_blank"} and pick up any available issue to submit a PR.
+    - You can simply visit their repository [here](https://github.com/novuhq/novu) and pick up any available issue to submit a PR.
     - The Novu team will review the pull request and let you know if any changes are needed.
     - After they have merged your 3 pull requests, you will be contacted over a GitHub discussion thread to claim your swag.
-- **Issues**: See the list of available Hacktoberfest issues [here](https://github.com/novuhq/novu/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest){:target="\_blank"}.
-- **Notes**: More details for the prizes [are here](https://twitter.com/novuhq/status/1576536573436637186){:target="\_blank"}. Also, you can join the official Novu Hacktoberfest kickoff on 3rd October 2022 by joining [here](https://discord.gg/K747c2mb?event=1025547200559861810){:target="\_blank"}. Join their [Discord](https://discord.gg/novu){:target="\_blank"} if you have any further queries.
+- **Issues**: See the list of available Hacktoberfest issues [here](https://github.com/novuhq/novu/issues?q=is%3Aissue+is%3Aopen+label%3AHacktoberfest).
+- **Notes**: More details for the prizes [are here](https://twitter.com/novuhq/status/1576536573436637186). Also, you can join the official Novu Hacktoberfest kickoff on 3rd October 2022 by joining [here](https://discord.gg/K747c2mb?event=1025547200559861810). Join their [Discord](https://discord.gg/novu) if you have any further queries.
 
 ### O
 
@@ -361,10 +361,10 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: T-shirt, Sticker Pack, Water Bottle
 - **Requirements**:
-    - Everyone who makes one or more contributions to the [OpenSearch](https://github.com/search?q=topic%3Ahacktoberfest+org%3Aopensearch-project+fork%3Atrue&type=repositories){:target="\_blank"} community during Hacktoberfest will be eligible for a free OpenSearch sticker.
+    - Everyone who makes one or more contributions to the [OpenSearch](https://github.com/search?q=topic%3Ahacktoberfest+org%3Aopensearch-project+fork%3Atrue&type=repositories) community during Hacktoberfest will be eligible for a free OpenSearch sticker.
     - The top 5 points scorers on the community leader board will get a swag pack that will include a water bottle, sweatshirt, and a sticker pack.
     - To get points for your contribution you must open an issue on GitHub and it must be tagged Hacktoberfest with the exception of the forum answers.
-    - To get credit for off platform blogs submit a link to your blog in an issue on the [opensearch-project/project-website](https://github.com/opensearch-project/project-website){:target="\_blank"} repo and ask for it to be tagged Hacktoberfest.
+    - To get credit for off platform blogs submit a link to your blog in an issue on the [opensearch-project/project-website](https://github.com/opensearch-project/project-website) repo and ask for it to be tagged Hacktoberfest.
     - Points for contributions are distributed as follows:
         - Feature: 10
         - Bug fix: 6
@@ -373,10 +373,10 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
         - Docs: 4
         - Forum answer: 3 (+2 if marked as solution)
 - **How to sign up**:
-    - You can simply visit one of their repositories [here](https://github.com/search?q=topic%3Ahacktoberfest+org%3Aopensearch-project+fork%3Atrue&type=repositories){:target="\_blank"} and pick up any available issue to submit a PR.
+    - You can simply visit one of their repositories [here](https://github.com/search?q=topic%3Ahacktoberfest+org%3Aopensearch-project+fork%3Atrue&type=repositories) and pick up any available issue to submit a PR.
     - The OpenSearch team will review the pull request and let you know if any changes are needed.
-- **Issues**: See the list of available Hacktoberfest issues [here](https://github.com/search?q=topic%3Ahacktoberfest+org%3Aopensearch-project+fork%3Atrue+label%3A%22hacktoberfest%22+is%3Aissue+is%3Aopen&type=Issues){:target="\_blank"}.
-- **Notes**: More details about the prizes [are here](https://opensearch.org/blog/community/2022/10/hacktoberfest-2022/){:target="\_blank"}. Join their [Forum](https://forum.opensearch.org/t/hacktoberfest-2022/11129){:target="\_blank"} if you have any further queries. They are also active on [Twitter](https://twitter.com/OpenSearchProj){:target="\_blank"}.
+- **Issues**: See the list of available Hacktoberfest issues [here](https://github.com/search?q=topic%3Ahacktoberfest+org%3Aopensearch-project+fork%3Atrue+label%3A%22hacktoberfest%22+is%3Aissue+is%3Aopen&type=Issues).
+- **Notes**: More details about the prizes [are here](https://opensearch.org/blog/community/2022/10/hacktoberfest-2022/). Join their [Forum](https://forum.opensearch.org/t/hacktoberfest-2022/11129) if you have any further queries. They are also active on [Twitter](https://twitter.com/OpenSearchProj).
 
 ### P
 
@@ -385,16 +385,16 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 - **Swag**: Percona T-shirt or a hat.
 - **Requirements**:
     - Submit at least 4 pull/merge requests that are:
-        - Following the [official Hacktoberfest PR/MR conditions](https://hacktoberfest.com/participation/#pr-mr-details){:target="\_blank"}.
-        - Getting accepted to any of the participating [Percona Github Repos](https://github.com/search?q=org%3Apercona+topic%3Ahacktoberfest){:target="\_blank"}.
+        - Following the [official Hacktoberfest PR/MR conditions](https://hacktoberfest.com/participation/#pr-mr-details).
+        - Getting accepted to any of the participating [Percona Github Repos](https://github.com/search?q=org%3Apercona+topic%3Ahacktoberfest).
 - **How to sign up**:
-    - Register on the [Hacktoberfest website](https://hacktoberfest.com/){:target="\_blank"} anytime between September 26 and October 31, 2022.
-    - Explore the [participating projects](https://github.com/search?q=org%3Apercona+topic%3Ahacktoberfest){:target="\_blank"} and choose your favorites. Contribute with PR/MRs during the period from October 1 to October 31, 2022.
+    - Register on the [Hacktoberfest website](https://hacktoberfest.com/) anytime between September 26 and October 31, 2022.
+    - Explore the [participating projects](https://github.com/search?q=org%3Apercona+topic%3Ahacktoberfest) and choose your favorites. Contribute with PR/MRs during the period from October 1 to October 31, 2022.
     - The Percona team will review your PRs constantly and give you feedback.
 - **Issues**:
-    - [Percona Github Issues](https://github.com/search?q=org%3Apercona+topic%3Ahacktoberfest+is%3Aissue+is%3Aopen&type=Issues){:target="\_blank"}
-    - [Percona JIRA Issues](https://jira.percona.com/issues/?jql=resolution%20%3D%20Unresolved%20AND%20status%20%3D%20Open%20AND%20description%20is%20not%20EMPTY%20AND%20project%20in%20(%22Percona%20Monitoring%20and%20Management%22%2C%20%22Percona%20Operator%20for%20MongoDB%22%2C%20%22Percona%20Operator%20for%20MySQL%22%2C%20%22Percona%20Operator%20for%20MySQL%20based%20on%20Percona%20XtraDB%20Cluster%22%2C%20%22Percona%20Operator%20for%20PostgreSQL%22)%20ORDER%20BY%20created%20DESC){:target="\_blank"}
-- **Notes**: Additional information regarding Hacktoberfest with Percona can be found in this [blog post](https://www.percona.com/blog/contribute-to-open-source-with-percona-and-hacktoberfest/){:target="\_blank"}.
+    - [Percona Github Issues](https://github.com/search?q=org%3Apercona+topic%3Ahacktoberfest+is%3Aissue+is%3Aopen&type=Issues)
+    - [Percona JIRA Issues](https://jira.percona.com/issues/?jql=resolution%20%3D%20Unresolved%20AND%20status%20%3D%20Open%20AND%20description%20is%20not%20EMPTY%20AND%20project%20in%20(%22Percona%20Monitoring%20and%20Management%22%2C%20%22Percona%20Operator%20for%20MongoDB%22%2C%20%22Percona%20Operator%20for%20MySQL%22%2C%20%22Percona%20Operator%20for%20MySQL%20based%20on%20Percona%20XtraDB%20Cluster%22%2C%20%22Percona%20Operator%20for%20PostgreSQL%22)%20ORDER%20BY%20created%20DESC)
+- **Notes**: Additional information regarding Hacktoberfest with Percona can be found in this [blog post](https://www.percona.com/blog/contribute-to-open-source-with-percona-and-hacktoberfest/).
 
 #### **Pusher**
 
@@ -404,9 +404,9 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Submit 2 pull requests and get them merged to receive two items from the Pusher Hacktoberfest swag pack.
     - Submit 3 or more pull requests and get them merged to receive the full Pusher Hacktoberfest swag pack.
 - **How to sign up**:
-    - Fork the README.MD file in the [pusher/hacktoberfest repo](https://github.com/pusher/hacktoberfest){:target="\_blank"} and make PR with a link to what you’ve worked on and an email address so they can reach out to you to claim your swag.
+    - Fork the README.MD file in the [pusher/hacktoberfest repo](https://github.com/pusher/hacktoberfest) and make PR with a link to what you’ve worked on and an email address so they can reach out to you to claim your swag.
     - You will receive a review, comment, and approval by a member of the Pusher team within a couple of days. All PRs accepted by the team will be marked as ‘hacktoberfest-accepted’ by October 31st.
-- **Notes**: More details [in the Pusher Hacktoberfest repo here](https://github.com/pusher/hacktoberfest/blob/main/README.md){:target="\_blank"}
+- **Notes**: More details [in the Pusher Hacktoberfest repo here](https://github.com/pusher/hacktoberfest/blob/main/README.md)
 
 ### R
 
@@ -418,20 +418,20 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Write tweets or threads. Each tweet earns 1 point. You can get only 1 point from Twitter. You will get one more point if the tweet/thread has more than 500 likes.
     - Publish YouTube videos about APIs. Each video on YouTube will earn you 2 points. If your video has more than 1k views, you will get two additional points.
     - Run an API development meetup. Talk about using RapidAPI VS Code extension or hosting APIs on RapidAPI Hub. Each meetup will earn you 4 points.
-- **How to sign up**: Submit your application to win swags from RapidAPI using the [contact form](https://docs.google.com/forms/d/e/1FAIpQLScBao9QuBPjAOgNK_2cCe2_8Y40dqvkS8f0DMpst-WopZOg8w/viewform?usp=sf_link){:target="\_blank"}
-- **Notes**: Only the first 50 participants who complete the challenge will be chosen as winners. For more details visit the [page](https://rapidapi.com/learn/hacktoberfest){:target="\_blank"}.
+- **How to sign up**: Submit your application to win swags from RapidAPI using the [contact form](https://docs.google.com/forms/d/e/1FAIpQLScBao9QuBPjAOgNK_2cCe2_8Y40dqvkS8f0DMpst-WopZOg8w/viewform?usp=sf_link)
+- **Notes**: Only the first 50 participants who complete the challenge will be chosen as winners. For more details visit the [page](https://rapidapi.com/learn/hacktoberfest).
 
 #### **Refine**
 
 - **Swag**: T-shirt, cap, bottle.
 - **Requirements**:
-    - Submit 1 pull request to the [refine repository](https://github.com/pankod/refine){:target="\_blank"} and get it merged to receive a refine T-shirt.
+    - Submit 1 pull request to the [refine repository](https://github.com/pankod/refine) and get it merged to receive a refine T-shirt.
     - Submit 2 pull requests and get them merged to receive a complete refine Swag Kit: T-shirt, cap & bottle.
 - **How to sign up**:
-    - Register on the [Hacktoberfest website](https://hacktoberfest.com/){:target="\_blank"} anytime between September 26 and October 31, 2022.
+    - Register on the [Hacktoberfest website](https://hacktoberfest.com/) anytime between September 26 and October 31, 2022.
     - Pick one of the issues in refine repository, submit a pull request and get it merged.
-- **Issues**: Here you can find a [list of Hacktoberfest labeled issues](https://github.com/pankod/refine/labels/hacktoberfest){:target="\_blank"} in refine repository.
-- **Notes**: More details [in the refine blogpost here](https://refine.dev/blog/hacktoberfest-refine/){:target="\_blank"}
+- **Issues**: Here you can find a [list of Hacktoberfest labeled issues](https://github.com/pankod/refine/labels/hacktoberfest) in refine repository.
+- **Notes**: More details [in the refine blogpost here](https://refine.dev/blog/hacktoberfest-refine/)
 
 ### S
 
@@ -439,11 +439,11 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: Space Jelly Sticker Pack, Cloudinary Sticker Pack, Cloudinary Plush Unicorn
 - **Requirements**:
-    - Submit 1 pull request and get it merged to receive Space Jelly Sticker Pack in the [Next.js WordPress Starter Repo](https://github.com/colbyfayock/next-wordpress-starter){:target="\_blank"}.
-    - Submit 1 pull request and get it merged to receive Space Jelly Sticker Pack, Cloudinary Sticker Pack, and Cloudinary Plush Unicorn in the [Cloudinary Next.js Image Component repo](https://github.com/colbyfayock/next-cloudinary){:target="\_blank"} OR [Cloudinary Netlify Plugin Repo](https://github.com/colbyfayock/netlify-plugin-cloudinary){:target="\_blank"}.
+    - Submit 1 pull request and get it merged to receive Space Jelly Sticker Pack in the [Next.js WordPress Starter Repo](https://github.com/colbyfayock/next-wordpress-starter).
+    - Submit 1 pull request and get it merged to receive Space Jelly Sticker Pack, Cloudinary Sticker Pack, and Cloudinary Plush Unicorn in the [Cloudinary Next.js Image Component repo](https://github.com/colbyfayock/next-cloudinary) OR [Cloudinary Netlify Plugin Repo](https://github.com/colbyfayock/netlify-plugin-cloudinary).
 - **How to sign up**:
-    - Register on the [Hacktoberfest website](https://hacktoberfest.com/){:target="\_blank"} anytime between September 26 and October 31, 2022.
-- **Notes**: More details [on their Hacktoberfest page here](https://spacejelly.dev/hacktoberfest/){:target="\_blank"}.
+    - Register on the [Hacktoberfest website](https://hacktoberfest.com/) anytime between September 26 and October 31, 2022.
+- **Notes**: More details [on their Hacktoberfest page here](https://spacejelly.dev/hacktoberfest/).
 
 #### Speckle
 
@@ -461,17 +461,17 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - 1 Low-code contribution for a next-level Steampipe Hacktoberfest sticker.
     - 1 High-code contribution for a Steampipe Hacktoberfest t-shirt.
     - 1 Advanced high-code contribution for a next-level Steampipe Hacktoberfest t-shirt.
-- **How to sign up**: No Special Sign-ups required. You can simply visit their repository [here](https://github.com/turbot/steampipe){:target="\_blank"} and pick up any available issue to submit a PR.
+- **How to sign up**: No Special Sign-ups required. You can simply visit their repository [here](https://github.com/turbot/steampipe) and pick up any available issue to submit a PR.
     - The Steampipe team will review the pull request and let you know if any changes are needed.
-- **Notes**: For more details [their Hacktoberfest page](https://steampipe.io/blog/hacktoberfest-2022){:target="\_blank"}.
+- **Notes**: For more details [their Hacktoberfest page](https://steampipe.io/blog/hacktoberfest-2022).
 
 #### **SuiteCRM**
 
 - **Swag**: T-shirt, stickers, SuiteCRM-branded mug
 - **Requirements**: Unsure as to number of PRs required at this time.
 - **How to sign up**: Unsure how they're tracking signups at this time.
-- **Issues**: [SuiteCRM](https://github.com/salesagility/SuiteCRM/labels/Hacktoberfest){:target="\_blank"}, [SuiteCRM-Core](https://github.com/salesagility/SuiteCRM-Core/labels/Hacktoberfest){:target="\_blank"}, [SuiteDocs](https://github.com/salesagility/SuiteDocs/labels/Hacktoberfest){:target="\_blank"}
-- **Notes**: For more details [see their Hacktoberfest community post](https://community.suitecrm.com/t/hacktoberfest-2022/86484){:target="\_blank"}
+- **Issues**: [SuiteCRM](https://github.com/salesagility/SuiteCRM/labels/Hacktoberfest), [SuiteCRM-Core](https://github.com/salesagility/SuiteCRM-Core/labels/Hacktoberfest), [SuiteDocs](https://github.com/salesagility/SuiteDocs/labels/Hacktoberfest)
+- **Notes**: For more details [see their Hacktoberfest community post](https://community.suitecrm.com/t/hacktoberfest-2022/86484)
 
 ### T
 
@@ -484,13 +484,13 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
     - Submit 4 valid PRs and get ToolJet stickers, t-shirt, hoodie, and water bottle.
     - Also, the top 5 contributors will get a surprise gift this time!
 - **How to sign up**:
-    - First [Sign up here](https://app.tooljet.com/signup){:target="\_blank"}.
+    - First [Sign up here](https://app.tooljet.com/signup).
     - Find an issue you can work according to the description and labels.
     - Get it assigned to yourself and then only raise a corresponding PR.
-- **Issues**: List of all [Hacktoberfest-labeled-issues](https://github.com/ToolJet/ToolJet/labels/hacktoberfest){:target="\_blank"}.
+- **Issues**: List of all [Hacktoberfest-labeled-issues](https://github.com/ToolJet/ToolJet/labels/hacktoberfest).
 - **Notes**:
-    - Checkout [this blog post](https://blog.tooljet.com/hacktoberfest-2022/){:target="\_blank"}.
-    - For help, join their [Slack](https://tooljet.com/slack){:target="\_blank"}.
+    - Checkout [this blog post](https://blog.tooljet.com/hacktoberfest-2022/).
+    - For help, join their [Slack](https://tooljet.com/slack).
 
 ### U
 
@@ -523,10 +523,10 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 ---
 
-*Disclaimer*: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/){:target="\_blank"} or any company offering swag.
+*Disclaimer*: This website is a fan and community made creation. It is not affiliated with [Hacktoberfest](https://hacktoberfest.digitalocean.com/) or any company offering swag.
 
 ![Presented by DigitalOcean](img/Hfest-Badge-2-Color-Manga.svg)
 
 ---
 
-If you're looking for the Swag List from 2018 through 2021 [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases){:target="\_blank"} for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags){:target="\_blank"} for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018){:target="\_blank"}, [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019){:target="\_blank"}, [2020](https://github.com/crweiner/hacktoberfest-swag-list/tree/2020){:target="\_blank"}, and [2021](https://github.com/crweiner/hacktoberfest-swag-list/tree/2021){:target="\_blank"} branches.
+If you're looking for the Swag List from 2018 through 2021 [click here](https://github.com/crweiner/hacktoberfest-swag-list/releases) for the GitHub releases, [click here](https://github.com/crweiner/hacktoberfest-swag-list/tags) for the tags, and see the [2018](https://github.com/crweiner/hacktoberfest-swag-list/tree/2018), [2019](https://github.com/crweiner/hacktoberfest-swag-list/tree/2019), [2020](https://github.com/crweiner/hacktoberfest-swag-list/tree/2020), and [2021](https://github.com/crweiner/hacktoberfest-swag-list/tree/2021) branches.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,3 +66,4 @@ extra:
 #Extensions
 markdown_extensions:
   - attr_list
+  - markdown3-newtab

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,4 +66,4 @@ extra:
 #Extensions
 markdown_extensions:
   - attr_list
-  - markdown3-newtab
+  - markdown-link-attr-modifier

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,4 +66,5 @@ extra:
 #Extensions
 markdown_extensions:
   - attr_list
-  - markdown-link-attr-modifier
+  - markdown_link_attr_modifier:
+      new_tab: external_only


### PR DESCRIPTION
This PR is to get the Python [markdown_link_attr_modifier](https://github.com/Phuker/markdown_link_attr_modifier) plugin working in MkDocs and Material to automatically write `target="_blank"` instead of having to  add that in Kramdown style `{:target="_blank"}`