### PR TITLE
Add pygments extension

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -68,3 +68,8 @@ markdown_extensions:
   - attr_list
   - markdown_link_attr_modifier:
       new_tab: external_only
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -12,6 +12,7 @@ theme:
   logo: img/Hfest-Badge-2-Color-Void.svg
   features: 
     - navigation.tracking
+    - content.code.annotate
   palette: 
     # Palette toggle for light mode
     - media: "(prefers-color-scheme: light)"


### PR DESCRIPTION
The recent update to the Contributing guidelines in PR #664 brought steps to build the site locally. I attempted to add syntax highlighting to code blocks following GitHub-flavored markdown, which I recently saw did not work on the live site. MkDocs requires the [Pygments extension](https://squidfunk.github.io/mkdocs-material/reference/code-blocks/) for lexing/syntax, so this PR tries to get that working.
