### PR TITLE
Fix a small copy-paste mistake concerncing dyrector.io

### DIFF
--- a/docs/list.md
+++ b/docs/list.md
@@ -121,7 +121,7 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 - **Swag**: Cap, stickers
 - **Requirements**: Contribute to any of issues.
 - **How to sign up**: No special signup known.
-- **Issues**: Check open issues at [docsGPT](https://github.com/dyrector-io/dyrectorio/issues).
+- **Issues**: Check open issues at [Dyrectorio](https://github.com/dyrector-io/dyrectorio/issues)
 - **Notes**: Read more at the [Hacktoberfest](https://github.com/dyrector-io/dyrectorio/issues/837) swag post.
 
 ### E


### PR DESCRIPTION
The URL was correct but it still mentioned "docsGPT" which was the listed project above it

![image](https://github.com/crweiner/hacktoberfest-swag-list/assets/6261556/8ab54206-6e28-4b20-b8f5-457be9f92af9)


1. [x] I have read the [Contributing.md](https://github.com/crweiner/hacktoberfest-swag-list/blob/master/docs/contributing.md) file and formatted this PR correctly
2. [x] I'm not adding a company from the blocklist
3. [x] I make sure to fix things promptly if an error or suggestion comes up

Tagging @crweiner to take a look. :eyes:
