### PR TITLE
Added the link to Mattermost repos

### DIFF
--- a/docs/list.md
+++ b/docs/list.md
@@ -416,7 +416,7 @@ Appwrite is a self-hosted backend-as-a-service platform that provides developers
 
 - **Swag**: Limited-Edition Swag.
 - **Requirements**:
-    - Contribute to any of the Mattermost projects or improve the documentation or improve accessibility with better translations.
+    - Contribute to any of the [Mattermost projects](https://github.com/orgs/mattermost/repositories) or improve the documentation or improve accessibility with better translations.
     - Make valid contribution to QA during Hacktoberfest for an extra swag.
 - **How to sign up**:  Join the [Mattermost channel](https://community.mattermost.com/landing#/core/channels/qa-contributors).
 - **Notes**: The Custom QA swag will be awarded with any other Mattermost swag you earn through other contributions. Check the Mattermost [Hacktoberfest 2023 page](https://mattermost.com/hacktoberfest/) for more details.


### PR DESCRIPTION
I have added link to the list of all Mattermost repos as earlier it didn't contain the link, so one has to manually search for the Mattermost repo to contribute. Thus, will save time for possible contributors to the repo.

Thanks for contributing to the [Hacktoberfest Swag List](https://hacktoberfestswaglist.com/) :smiley: :tada:! Before submitting your pull request, please check off as many of the items below as you can:

1. [x] I have read the [Contributing.md](https://github.com/crweiner/hacktoberfest-swag-list/blob/master/docs/contributing.md) file and formatted this PR correctly
2. [x] I'm not adding a company from the blocklist
3. [x] I make sure to fix things promptly if an error or suggestion comes up

Thanks and Happy Hacktoberfest! :tada:
Tagging @crweiner to take a look. :eyes:
