### PR TITLE
Update contributing guide, mkdocs config and fix some broken images.

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,6 +1,7 @@
 # Hacktoberfest Swag List 2025
 
-![Hacktoberfest logo](docs/img/HF-Stacked-Color-Light.png)
+![Hacktoberfest logo](docs/img/HF-Stacked-Color-Light.png#gh-light-mode-only)
+![Hacktoberfest logo](docs/img/HF-Stacked-Color-Dark.png#gh-dark-mode-only)
 
 Hello all you beautiful nerds and welcome to another year of [Hacktoberfest](https://hacktoberfest.com/)! at the [Hacktoberfest Swag List](https://hacktoberfestswaglist.com)
 

--- a/Readme.md
+++ b/Readme.md
@@ -1,7 +1,7 @@
 # Hacktoberfest Swag List 2025
 
-![Hacktoberfest logo](docs/img/HF-Stacked-Color-Light.png#gh-light-mode-only)
-![Hacktoberfest logo](docs/img/HF-Stacked-Color-Dark.png#gh-dark-mode-only)
+![Hacktoberfest logo](docs/img/HF-Stacked-Color-Light.png#gh-dark-mode-only)
+![Hacktoberfest logo](docs/img/HF-Stacked-Color-Dark.png#gh-light-mode-only)
 
 Hello all you beautiful nerds and welcome to another year of [Hacktoberfest](https://hacktoberfest.com/)! at the [Hacktoberfest Swag List](https://hacktoberfestswaglist.com)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -75,7 +75,7 @@ To get the site up and running locally, follow the below steps:
   cd hacktoberfest-swag-list
   ```
 
-### Run MkDocs
+### Method 1: Setting up MkDocs locally
 
 * Install the required dependencies
 
@@ -91,7 +91,7 @@ To get the site up and running locally, follow the below steps:
 
 Please make sure you are always making changes in the Markdown docs located in `/docs/` and do not edit the HTML that MkDocs builds in the `/site/` directory.
 
-### Setting up the site using Docker
+### Method 2: Setting up the site using Docker
 
 Alternatively, you can use the native [Mkdocs-Material Docker imgage](https://hub.docker.com/r/squidfunk/mkdocs-material) to build this site locally. The Dockerfile found here pulls in the Mkdocs-Material Docker image and adds the `markdown-link-attr-modifier` plugin so that the links continue to open in new tabs without having to add the tags manually.
 
@@ -108,6 +108,14 @@ Run the Docker instance:
 ```bash
 
 docker run --rm -it -p 8000:8000 -v ${PWD}:/docs squidfunk/mkdocs-material
+
+```
+
+This command works on Windows when using PowerShell. If you are using  Command Prompt (cmd), use the following command instead:
+
+```bash
+
+docker run --rm -it -p 8000:8000 -v %cd%:/docs squidfunk/mkdocs-material
 
 ```
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 ## Hacktoberfest 2025 Is Here
 
 [![Hacktoberfest 2025 Banner](img/HF-Horizontal-Color-Light.svg#only-dark)](list.md)
-[![Hacktoberfest 2025 Banner](img/HF-Horizontal-Color-dark.svg#only-light)](list.md)
+[![Hacktoberfest 2025 Banner](img/HF-Horizontal-Color-Dark.svg#only-light)](list.md)
 
 Hello all you beautiful nerds and welcome to another year of [Hacktoberfest](https://hacktoberfest.com/)!
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -4,7 +4,6 @@ site_description: "Connecting contributors to open-source projects during Hackto
 site_author: "crweiner"
 site_url: "https://hacktoberfestswaglist.com"
 
-site_name: Hacktoberfest Swag List
 docs_dir: "docs"
 theme:
   favicon: img/favicon.ico
@@ -51,8 +50,6 @@ nav:
   # Customization
 extra_javascript:
   - "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.6/MathJax.js?config=TeX-MML-AM_CHTML"
-extra_css:
-  - "assets/css/custom.css"
 extra:
   manifest: "manifest.json"
   social:


### PR DESCRIPTION
1. [x] I have read the [Contributing.md](https://github.com/crweiner/hacktoberfest-swag-list/blob/master/docs/contributing.md) file and formatted this PR correctly
2. [x] I'm not adding a company from the blocklist
3. [x] I make sure to fix things promptly if an error or suggestion comes up

I was running it locally and noticed a few errors and issues. This is my attempt to fix those :)

## Update contributing guide
- Made it clear from the beginning the two methods to setup locally.
- As always, nothing is so easy with Windows so fixed Docker instructions for Windows users.

## MkDocs config update
- Removed a duplicate key `site_name`, I removed and did not see it affect anything that changed in the final build. Hope it was just a duplicate.
- I don't see any extra css, might be from when you had some custom css?

## Update README
For light theme users like me, the light logo is barely visible. Also since you already have the logos why not use them both! 
Added the image and appropriate anchor tag to the appropriate images based on the user theme. 
Since you likely are a dark theme user, attaching screenshots
<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/bc9ff7b1-297e-4ae1-9fd4-917cf2538cfc" />
<img width="50%" height="50%" alt="image" src="https://github.com/user-attachments/assets/eb5a96a7-8fc8-445f-8d9b-e07df1d6e8d0" />

## Fix image in index.md
MkDocs kept warning about the missing image and would not load the logo locally. That being said, the deployed build does not have any problem with wrong image name. 
It was just a typo of `HF-Horizontal-Color-Dark.svg` and `HF-Horizontal-Color-dark.svg` so fixed it. It does not seem to make any difference to load the image. So kudos! to modern browsers?

Please let me know if some or most changes aren't welcome, I can fix or remove those commits as needed.

Thanks and Happy Hacktoberfest! :tada:
Tagging @crweiner to take a look. :eyes:

